### PR TITLE
Add Exit Status in Result

### DIFF
--- a/packages/host/src/index.ts
+++ b/packages/host/src/index.ts
@@ -1,5 +1,5 @@
 import { ParentHandshake, RemoteHandle, WindowMessenger } from "post-me";
-import { Runtime, RuntimeMethods, CommandResult, FS, Syntax } from "./types";
+import { Runtime, RuntimeMethods, RunResult, FS, Syntax } from "./types";
 import { encode } from "url-safe-base64";
 
 export function generateEmbedURL(
@@ -90,7 +90,7 @@ export class RunnoHost implements RuntimeMethods {
     return this.remoteHandle.call("getEditorProgram");
   }
 
-  interactiveRunCode(runtime: Runtime, code: string): Promise<CommandResult> {
+  interactiveRunCode(runtime: Runtime, code: string): Promise<RunResult> {
     return this.remoteHandle.call("interactiveRunCode", runtime, code);
   }
 
@@ -98,11 +98,11 @@ export class RunnoHost implements RuntimeMethods {
     runtime: Runtime,
     entryPath: string,
     fs: FS
-  ): Promise<CommandResult> {
+  ): Promise<RunResult> {
     return this.remoteHandle.call("interactiveRunFS", runtime, entryPath, fs);
   }
 
-  interactiveUnsafeCommand(command: string, fs: FS): Promise<CommandResult> {
+  interactiveUnsafeCommand(command: string, fs: FS): Promise<RunResult> {
     return this.remoteHandle.call("interactiveUnsafeCommand", command, fs);
   }
 
@@ -114,7 +114,7 @@ export class RunnoHost implements RuntimeMethods {
     runtime: Runtime,
     code: string,
     stdin?: string
-  ): Promise<CommandResult> {
+  ): Promise<RunResult> {
     return this.remoteHandle.call("headlessRunCode", runtime, code, stdin);
   }
 
@@ -123,7 +123,7 @@ export class RunnoHost implements RuntimeMethods {
     entryPath: string,
     fs: FS,
     stdin?: string
-  ): Promise<CommandResult> {
+  ): Promise<RunResult> {
     return this.remoteHandle.call(
       "headlessRunFS",
       runtime,
@@ -137,7 +137,7 @@ export class RunnoHost implements RuntimeMethods {
     command: string,
     fs: FS,
     stdin?: string
-  ): Promise<CommandResult> {
+  ): Promise<RunResult> {
     return this.remoteHandle.call("headlessUnsafeCommand", command, fs, stdin);
   }
 }

--- a/packages/host/src/types.ts
+++ b/packages/host/src/types.ts
@@ -7,13 +7,12 @@ export type CommandResult = {
   stderr: string;
   tty: string;
   fs: FS;
-  prepareResult?: {
-    stdin: string;
-    stdout: string;
-    stderr: string;
-    tty: string;
-    fs: FS;
-  };
+  exit: number;
+};
+
+export type RunResult = {
+  result?: CommandResult;
+  prepare?: CommandResult;
 };
 
 export type FS = {
@@ -38,18 +37,15 @@ export type RuntimeMethods = {
 
   getEditorProgram: () => Promise<string>;
 
-  interactiveRunCode: (
-    runtime: Runtime,
-    code: string
-  ) => Promise<CommandResult>;
+  interactiveRunCode: (runtime: Runtime, code: string) => Promise<RunResult>;
 
   interactiveRunFS: (
     runtime: Runtime,
     entryPath: string,
     fs: FS
-  ) => Promise<CommandResult>;
+  ) => Promise<RunResult>;
 
-  interactiveUnsafeCommand: (command: string, fs: FS) => Promise<CommandResult>;
+  interactiveUnsafeCommand: (command: string, fs: FS) => Promise<RunResult>;
 
   interactiveStop: () => void;
 
@@ -57,18 +53,18 @@ export type RuntimeMethods = {
     runtime: Runtime,
     code: string,
     stdin?: string
-  ) => Promise<CommandResult>;
+  ) => Promise<RunResult>;
 
   headlessRunFS: (
     runtime: Runtime,
     entryPath: string,
     fs: FS,
     stdin?: string
-  ) => Promise<CommandResult>;
+  ) => Promise<RunResult>;
 
   headlessUnsafeCommand: (
     command: string,
     fs: FS,
     stdin?: string
-  ) => Promise<CommandResult>;
+  ) => Promise<RunResult>;
 };

--- a/packages/runtime/src/run.ts
+++ b/packages/runtime/src/run.ts
@@ -2,13 +2,7 @@ import { html, css, LitElement } from "lit";
 import { property, state } from "lit/decorators.js";
 import { createRef, Ref, ref } from "lit/directives/ref.js";
 
-import {
-  Runtime,
-  RuntimeMethods,
-  Syntax,
-  CommandResult,
-  FS,
-} from "@runno/host";
+import { Runtime, RuntimeMethods, Syntax, RunResult, FS } from "@runno/host";
 import { EditorElement } from "./editor";
 import { ControlsElement } from "./controls";
 import { TerminalElement } from "./terminal";
@@ -56,7 +50,7 @@ export class RunElement extends LitElement implements RuntimeMethods {
     return this._running;
   }
 
-  public async run(): Promise<CommandResult> {
+  public async run(): Promise<RunResult> {
     const editor = this.editorRef.value!;
     if (!editor.runtime) {
       throw new Error("The editor has no runtime");
@@ -101,10 +95,7 @@ export class RunElement extends LitElement implements RuntimeMethods {
     return this._provider.getEditorProgram();
   }
 
-  async interactiveRunCode(
-    runtime: Runtime,
-    code: string
-  ): Promise<CommandResult> {
+  async interactiveRunCode(runtime: Runtime, code: string): Promise<RunResult> {
     this._running = true;
     const result = await this._provider.interactiveRunCode(runtime, code);
     this._running = false;
@@ -115,7 +106,7 @@ export class RunElement extends LitElement implements RuntimeMethods {
     runtime: Runtime,
     entryPath: string,
     fs: FS
-  ): Promise<CommandResult> {
+  ): Promise<RunResult> {
     this._running = true;
     const result = await this._provider.interactiveRunFS(
       runtime,
@@ -126,10 +117,7 @@ export class RunElement extends LitElement implements RuntimeMethods {
     return result;
   }
 
-  async interactiveUnsafeCommand(
-    command: string,
-    fs: FS
-  ): Promise<CommandResult> {
+  async interactiveUnsafeCommand(command: string, fs: FS): Promise<RunResult> {
     this._running = true;
     const result = await this._provider.interactiveUnsafeCommand(command, fs);
     this._running = false;
@@ -144,7 +132,7 @@ export class RunElement extends LitElement implements RuntimeMethods {
     runtime: Runtime,
     code: string,
     stdin?: string
-  ): Promise<CommandResult> {
+  ): Promise<RunResult> {
     return this._provider.headlessRunCode(runtime, code, stdin);
   }
 
@@ -153,7 +141,7 @@ export class RunElement extends LitElement implements RuntimeMethods {
     entryPath: string,
     fs: FS,
     stdin?: string
-  ): Promise<CommandResult> {
+  ): Promise<RunResult> {
     return this._provider.headlessRunFS(runtime, entryPath, fs, stdin);
   }
 
@@ -161,7 +149,7 @@ export class RunElement extends LitElement implements RuntimeMethods {
     command: string,
     fs: FS,
     stdin?: string
-  ): Promise<CommandResult> {
+  ): Promise<RunResult> {
     return this._provider.headlessUnsafeCommand(command, fs, stdin);
   }
 

--- a/packages/runtime/src/terminal.ts
+++ b/packages/runtime/src/terminal.ts
@@ -116,7 +116,7 @@ export class TerminalElement extends HTMLElement {
     for (const [filename, content] of Object.entries(result.fs)) {
       newfs[filename] = {
         name: filename,
-        content: content as Uint8Array,
+        content: content as unknown as Uint8Array,
       };
     }
     return result;

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -31,6 +31,7 @@
     "docs": "npx typedoc src/ --out docs --target es6 --theme minimal --mode file"
   },
   "dependencies": {
+    "@runno/host": "^0.1.6",
     "@runno/wasi": "^0.1.6",
     "@wasmer/io-devices": "^0.10.2",
     "@wasmer/wasmfs": "^0.10.2",

--- a/packages/terminal/src/command-runner/command-runner.ts
+++ b/packages/terminal/src/command-runner/command-runner.ts
@@ -4,20 +4,14 @@ import * as Comlink from "comlink";
 // @ts-ignore
 import parse from "shell-parse";
 
+import { CommandResult } from "@runno/host";
+
 import Process from "../process/process";
 import CommandOptions from "../command/command-options";
 
 import WasmTerminalConfig from "../wasm-terminal-config";
 
 import WasmTty from "../wasm-tty/wasm-tty";
-
-export type CommandResult = {
-  stdout: string;
-  stdin: string;
-  stderr: string;
-  tty: string;
-  fs: any;
-};
 
 type WorkerProcessData = {
   process: Comlink.Remote<Process>;
@@ -132,6 +126,7 @@ export default class CommandRunner {
         stderr: this.stderr,
         tty: this.tty,
         fs: {},
+        exit: 1,
       });
       return;
     }
@@ -164,6 +159,7 @@ export default class CommandRunner {
       stderr: this.stderr,
       tty: this.tty,
       fs: {},
+      exit: 1,
     });
   }
 
@@ -452,7 +448,8 @@ export default class CommandRunner {
       commandOptionIndex: number;
       processWorker?: Worker;
     },
-    wasmFsJson: any
+    wasmFsJson: any,
+    exitStatus: number
   ) {
     const { commandOptionIndex, processWorker } = endCallbackConfig;
 
@@ -480,6 +477,7 @@ export default class CommandRunner {
         stderr: this.stderr,
         tty: this.tty,
         fs: wasmFsJson,
+        exit: exitStatus,
       });
     }
 
@@ -511,6 +509,7 @@ export default class CommandRunner {
       stderr: this.stderr,
       tty: this.tty,
       fs: wasmFsJson,
+      exit: 1,
     });
   }
 

--- a/packages/terminal/src/wasm-shell/wasm-shell.ts
+++ b/packages/terminal/src/wasm-shell/wasm-shell.ts
@@ -1,5 +1,7 @@
 import { IBufferLine } from "xterm";
 
+import { CommandResult } from "@runno/host";
+
 import {
   ActiveCharPrompt,
   ActivePrompt,
@@ -16,10 +18,7 @@ import WasmTerminalConfig from "../wasm-terminal-config";
 
 import WasmTty from "../wasm-tty/wasm-tty";
 
-import {
-  default as CommandRunner,
-  CommandResult,
-} from "../command-runner/command-runner";
+import { default as CommandRunner } from "../command-runner/command-runner";
 
 /**
  * A shell is the primary interface that is used to start other programs.

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -440,7 +440,7 @@ print(f"G'day {name}, welcome to Runno.")
               <code>interactiveRunCode</code>.
             </p>
 
-            <pre><code>const result = await runno.interactiveRunCode("python", codeSample);</code></pre>
+            <pre><code>const { result } = await runno.interactiveRunCode("python", codeSample);</code></pre>
 
             <p>
               The result has properties for <code>stdin</code>,
@@ -455,7 +455,7 @@ print(f"G'day {name}, welcome to Runno.")
               <code>headlessRunCode</code>.
             </p>
 
-            <pre><code>const result = await runno.headlessRunCode("python", codeSample, stdin);</code></pre>
+            <pre><code>const { result } = await runno.headlessRunCode("python", codeSample, stdin);</code></pre>
 
             <p>
               The <code>stdin</code> is optional, but necessary if the code
@@ -686,7 +686,7 @@ Cross-Origin-Embedder-Policy: require-corp</code></pre>
             <p>Gets the current program in the editor.</p>
 
             <h4><code>interactiveRunCode</code></h4>
-            <pre><code>interactiveRunCode(runtime: Runtime, code: string): Promise&lt;CommandResult&gt;</code></pre>
+            <pre><code>interactiveRunCode(runtime: Runtime, code: string): Promise&lt;RunResult&gt;</code></pre>
             <p>
               Runs some code interactively using the given <code>Runtime</code>.
               It does not change or update the program in the editor.
@@ -697,7 +697,7 @@ Cross-Origin-Embedder-Policy: require-corp</code></pre>
   runtime: Runtime,
   entryPath: string,
   fs: FS
-): Promise&lt;CommandResult&gt;</code></pre>
+): Promise&lt;RunResult&gt;</code></pre>
             <p>
               Runs a filesystem object interactively using the given
               <code>Runtime</code>. The <code>entryPath</code> is used as the
@@ -706,7 +706,7 @@ Cross-Origin-Embedder-Policy: require-corp</code></pre>
             </p>
 
             <h4><code>interactiveUnsafeCommand</code></h4>
-            <pre><code>interactiveUnsafeCommand(command: string, fs: FS): Promise&lt;CommandResult&gt;</code></pre>
+            <pre><code>interactiveUnsafeCommand(command: string, fs: FS): Promise&lt;RunResult&gt;</code></pre>
             <p>
               Runs a concrete command in a similar way to
               <a target="_blank" href="https://webassembly.sh">
@@ -728,7 +728,7 @@ Cross-Origin-Embedder-Policy: require-corp</code></pre>
   runtime: Runtime,
   code: string,
   stdin?: string
-): Promise&lt;CommandResult&gt;</code></pre>
+): Promise&lt;RunResult&gt;</code></pre>
             <p>
               Runs code headlessly. The user will not have an opportunity to
               interact with this code. You can provide <code>stdin</code> to
@@ -742,7 +742,7 @@ Cross-Origin-Embedder-Policy: require-corp</code></pre>
   entryPath: string,
   fs: FS,
   stdin?: string
-): Promise&lt;CommandResult&gt;</code></pre>
+): Promise&lt;RunResult&gt;</code></pre>
             <p>
               Corresponding headless version of running with an FS. See:
               <code>interactiveRunFS</code>
@@ -753,7 +753,7 @@ Cross-Origin-Embedder-Policy: require-corp</code></pre>
   command: string,
   fs: FS,
   stdin?: string
-): Promise&lt;CommandResult&gt;</code></pre>
+): Promise&lt;RunResult&gt;</code></pre>
             <p>
               Corresponding headless version of running an unsafe command. See:
               <code>interactiveUnsafeCommand</code>
@@ -776,18 +776,19 @@ Cross-Origin-Embedder-Policy: require-corp</code></pre>
   stderr: string;
   tty: string;
   fs: FS;
-  prepareResult?: {
-    stdin: string;
-    stdout: string;
-    stderr: string;
-    tty: string;
-    fs: FS;
-  };
+  exit: number;
+};</code></pre>
+            <p>The result from running a command.</p>
+
+            <h4><code>RunResult</code></h4>
+            <pre><code>export type RunResult = {
+  result?: CommandResult;
+  prepare?: CommandResult;
 };</code></pre>
             <p>
-              The result from running a command. If the command has a
+              The result from running using Runno. If the runtime has a
               compilation or other type of preparation then the output from this
-              step will be in the optional <code>prepareResult</code> field.
+              step will be in the optional <code>prepare</code> field.
             </p>
 
             <h4><code>FS</code></h4>
@@ -976,8 +977,7 @@ print('Hello, World!')
               </li>
               <li>
                 <code
-                  >runCommand(command: string):
-                  Promise&lt;CommandResult&gt;</code
+                  >runCommand(command: string): Promise&lt;RunResult&gt;</code
                 >
                 - Runs a raw command (see:
                 <code>interactiveUnsafeCommand</code>)
@@ -1040,7 +1040,7 @@ print('Hello, World!')
   command: string,
   fs: FS,
   stdin?: string
-): Promise&lt;CommandResult&gt;</code></pre>
+): Promise&lt;RunResult&gt;</code></pre>
             <p>
               Same as <code>headlessUnsafeCommand</code> in the Host API. Handy
               if you want to use Runno's runtime without any UI.

--- a/packages/website/src/editor.ts
+++ b/packages/website/src/editor.ts
@@ -22,30 +22,34 @@ ConnectRunno(runtimeIframe).then((runno: RunnoHost) => {
   runButton.addEventListener("click", async function () {
     const code = codeEl.value;
 
-    const { stdin, stdout, stderr, tty } = await runno.interactiveRunCode(
+    const { result } = await runno.interactiveRunCode(
       runtimeSelect.value as Runtime,
       code
     );
 
-    stdoutEl.textContent = stdout;
-    stdinEl.textContent = stdin;
-    stderrEl.textContent = stderr;
-    ttyEl.textContent = tty;
+    if (result) {
+      stdoutEl.textContent = result.stdout;
+      stdinEl.textContent = result.stdin;
+      stderrEl.textContent = result.stderr;
+      ttyEl.textContent = result.tty;
+    }
   });
 
   headlessButton.addEventListener("click", async function () {
     const code = codeEl.value;
     const codeStdin = headlessStdinEl.value;
 
-    const { stdin, stdout, stderr, tty } = await runno.headlessRunCode(
+    const { result } = await runno.headlessRunCode(
       runtimeSelect.value as Runtime,
       code,
       codeStdin
     );
 
-    stdoutEl.textContent = stdout;
-    stdinEl.textContent = stdin;
-    stderrEl.textContent = stderr;
-    ttyEl.textContent = tty;
+    if (result) {
+      stdoutEl.textContent = result.stdout;
+      stdinEl.textContent = result.stdin;
+      stderrEl.textContent = result.stderr;
+      ttyEl.textContent = result.tty;
+    }
   });
 });


### PR DESCRIPTION
Add process exit status to result
  * Refactor result to make sense if the prepare step exits
  * Pass exit status up as part of result
  * Return an error status for various error states
  * Fixes #60 by stopping the command if the prepare fails