### PR TITLE
Update embedded style

### DIFF
--- a/packages/runtime/src/run.ts
+++ b/packages/runtime/src/run.ts
@@ -29,6 +29,7 @@ export class RunElement extends LitElement implements RuntimeMethods {
 
     runno-terminal {
       flex-grow: 1;
+      height: 150px;
     }
   `;
 

--- a/packages/runtime/src/run.ts
+++ b/packages/runtime/src/run.ts
@@ -21,6 +21,7 @@ export class RunElement extends LitElement implements RuntimeMethods {
       background: white;
       color: black;
       max-height: 70vh;
+      overflow: auto;
     }
 
     runno-controls {


### PR DESCRIPTION
I have found that in my personal testing that these changes make the editor much more usable.

![image](https://user-images.githubusercontent.com/22492406/161970428-c6cce756-fe8a-4d46-962f-df853b5fa3de.png)
vs
![image](https://user-images.githubusercontent.com/22492406/161970520-0183e40b-5e84-4f1e-94df-892e51f8fcd5.png)

I'm not sure if a better way exists to correctly style the terminal but this was the best I could find.