### PR TITLE
Fix wasi-drive read/resize in @runno/wasi

### DIFF
--- a/packages/wasi/lib/wasi/wasi-drive.ts
+++ b/packages/wasi/lib/wasi/wasi-drive.ts
@@ -505,13 +505,13 @@ class OpenFile {
   }
 
   read(bytes: number) {
-    const ret = this.buffer.slice(this.offset, bytes);
+    const ret = this.buffer.subarray(this.offset, this.offset + bytes);
     this._offset += BigInt(ret.length);
     return ret;
   }
 
   pread(bytes: number, offset: number) {
-    return this.buffer.slice(offset, bytes);
+    return this.buffer.subarray(offset, this.offset + bytes);
   }
 
   write(data: Uint8Array) {
@@ -637,7 +637,7 @@ class OpenFile {
     let underBuffer: ArrayBuffer;
 
     if (this.buffer.buffer.byteLength === 0) {
-      underBuffer = new ArrayBuffer(1024);
+      underBuffer = new ArrayBuffer(requiredBytes < 1024 ? 1024 : requiredBytes * 2);
     } else if (requiredBytes > this.buffer.buffer.byteLength * 2) {
       underBuffer = new ArrayBuffer(requiredBytes * 2);
     } else {

--- a/packages/wasi/lib/wasi/wasi-drive.ts
+++ b/packages/wasi/lib/wasi/wasi-drive.ts
@@ -511,7 +511,7 @@ class OpenFile {
   }
 
   pread(bytes: number, offset: number) {
-    return this.buffer.subarray(offset, this.offset + bytes);
+    return this.buffer.subarray(offset, offset + bytes);
   }
 
   write(data: Uint8Array) {


### PR DESCRIPTION
G'day @taybenlor

I came across two bugs while attempting to use `@runno/wasi` with a .NET CLI app compiled using the `wasi-experimental` workload.

1. `pread` and `read` in `OpenFile` was calling `slice()` with the assumption the second parameter is the length of bytes to read, [however it's the *end index* not the byte length](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/slice#parameters). I've also swapped this over to using [`subarray`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/subarray) which makes a new `Uint8Array` ontop of the same buffer, rather than copying the bytes. This should be a bit more performant, and I can't see any side-effects in my testing though maybe that's something you want to verify.
2. `resize` if called with a `requestedBytes` greater than `1024` for the first write would fail, as the new buffer is always `1024` in length (for example the default write buffer len for .NET is `4096`). I've just made it double the write length which seems to work fine.