### PR TITLE
Fix for base fs in headless mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4473,6 +4473,7 @@
     },
     "node_modules/js-untar": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -9421,7 +9422,7 @@
         "url-safe-base64": "^1.1.1"
       },
       "devDependencies": {
-        "@playwright/test": "^1.35.0",
+        "@playwright/test": "^1.37.1",
         "@types/url-safe-base64": "^1.1.0",
         "eslint": "^8.2.0",
         "typescript": "^5.1.6",
@@ -9590,7 +9591,6 @@
         "@obsidize/tar-browserify": "^3.0.0",
         "@runno/host": "^0.5.1",
         "@runno/wasi": "^0.5.1",
-        "js-untar": "^2.0.0",
         "lit": "^2.7.6",
         "pako": "^1.0.11",
         "runno-codemirror-lang-ruby": "^0.0.2",
@@ -11172,7 +11172,7 @@
     "@runno/client": {
       "version": "file:packages/client",
       "requires": {
-        "@playwright/test": "^1.35.0",
+        "@playwright/test": "^1.37.1",
         "@runno/host": "^0.5.1",
         "@runno/runtime": "^0.5.1",
         "@types/url-safe-base64": "^1.1.0",
@@ -11274,7 +11274,6 @@
         "@runno/host": "^0.5.1",
         "@runno/wasi": "^0.5.1",
         "eslint": "^7.28.0",
-        "js-untar": "^2.0.0",
         "lit": "^2.7.6",
         "pako": "^1.0.11",
         "runno-codemirror-lang-ruby": "^0.0.2",
@@ -13632,7 +13631,8 @@
       "dev": true
     },
     "js-untar": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "dev": true
     },
     "js-yaml": {
       "version": "4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1044,6 +1044,19 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@obsidize/tar-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@obsidize/tar-browserify/-/tar-browserify-3.0.0.tgz",
+      "integrity": "sha512-Gc5M9Sf/2lg34GGaI8eu891WNOS6yUwxQxSQxQYEOUf6AboQ00JHR874Us7ca7XssVcGaR+6w+K1PEQ2W1H7Jw==",
+      "dependencies": {
+        "tslib": "2.4.1"
+      }
+    },
+    "node_modules/@obsidize/tar-browserify/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
     "node_modules/@octokit/auth-token": {
       "version": "3.0.4",
       "dev": true,
@@ -1225,12 +1238,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.35.0",
+      "version": "1.37.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.37.1.tgz",
+      "integrity": "sha512-bq9zTli3vWJo8S3LwB91U0qDNQDpEXnw7knhxLM0nwDvexQAwx9tO8iKDZSqqneVq+URd/WIoz+BALMqUTgdSg==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.35.0"
+        "playwright-core": "1.37.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -6899,9 +6913,10 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.35.0",
+      "version": "1.37.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.37.1.tgz",
+      "integrity": "sha512-17EuQxlSIYCmEMwzMqusJ2ztDgJePjrbttaefgdsiqeLWidjYz9BxXaTaZWxH1J95SHGk6tjE+dwgWILJoUZfA==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -9572,6 +9587,7 @@
         "@codemirror/language": "^0.19.0",
         "@codemirror/rectangular-selection": "^0.19.2",
         "@codemirror/view": "^0.19.31",
+        "@obsidize/tar-browserify": "^3.0.0",
         "@runno/host": "^0.5.1",
         "@runno/wasi": "^0.5.1",
         "js-untar": "^2.0.0",
@@ -9583,6 +9599,7 @@
         "xterm-addon-web-links": "^0.6.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.37.1",
         "@rollup/plugin-typescript": "^8.2.5",
         "eslint": "^7.28.0",
         "typedoc": "^0.24.8",
@@ -9924,7 +9941,7 @@
       "version": "0.5.1",
       "license": "MIT",
       "devDependencies": {
-        "@playwright/test": "^1.26.1",
+        "@playwright/test": "^1.37.1",
         "typedoc": "^0.24.8",
         "typescript": "^5.1.6",
         "vite": "^4.4.9"
@@ -10991,6 +11008,21 @@
       "dev": true,
       "optional": true
     },
+    "@obsidize/tar-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@obsidize/tar-browserify/-/tar-browserify-3.0.0.tgz",
+      "integrity": "sha512-Gc5M9Sf/2lg34GGaI8eu891WNOS6yUwxQxSQxQYEOUf6AboQ00JHR874Us7ca7XssVcGaR+6w+K1PEQ2W1H7Jw==",
+      "requires": {
+        "tslib": "2.4.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
+      }
+    },
     "@octokit/auth-token": {
       "version": "3.0.4",
       "dev": true
@@ -11110,12 +11142,14 @@
       "optional": true
     },
     "@playwright/test": {
-      "version": "1.35.0",
+      "version": "1.37.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.37.1.tgz",
+      "integrity": "sha512-bq9zTli3vWJo8S3LwB91U0qDNQDpEXnw7knhxLM0nwDvexQAwx9tO8iKDZSqqneVq+URd/WIoz+BALMqUTgdSg==",
       "dev": true,
       "requires": {
         "@types/node": "*",
         "fsevents": "2.3.2",
-        "playwright-core": "1.35.0"
+        "playwright-core": "1.37.1"
       }
     },
     "@rollup/plugin-typescript": {
@@ -11234,6 +11268,8 @@
         "@codemirror/language": "^0.19.0",
         "@codemirror/rectangular-selection": "^0.19.2",
         "@codemirror/view": "^0.19.31",
+        "@obsidize/tar-browserify": "^3.0.0",
+        "@playwright/test": "^1.37.1",
         "@rollup/plugin-typescript": "^8.2.5",
         "@runno/host": "^0.5.1",
         "@runno/wasi": "^0.5.1",
@@ -11452,7 +11488,7 @@
     "@runno/wasi": {
       "version": "file:packages/wasi",
       "requires": {
-        "@playwright/test": "^1.26.1",
+        "@playwright/test": "^1.37.1",
         "typedoc": "^0.24.8",
         "typescript": "^5.1.6",
         "vite": "^4.4.9"
@@ -15204,7 +15240,9 @@
       }
     },
     "playwright-core": {
-      "version": "1.35.0",
+      "version": "1.37.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.37.1.tgz",
+      "integrity": "sha512-17EuQxlSIYCmEMwzMqusJ2ztDgJePjrbttaefgdsiqeLWidjYz9BxXaTaZWxH1J95SHGk6tjE+dwgWILJoUZfA==",
       "dev": true
     },
     "please-upgrade-node": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "build:deploy": "npm run bootstrap && npm run build",
     "test:client": "cd packages/client && npm run test",
     "test:wasi": "cd packages/wasi && npm run test:prepare && npm run test",
-    "test": "npm run test:client && npm run test:wasi"
+    "test:runtime": "cd packages/runtime && npm run test",
+    "test": "npm run test:client && npm run test:wasi && npm run test:runtime"
   },
   "eslintConfig": {
     "extends": "preact",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -26,7 +26,7 @@
     "test": "npm run test:playwright"
   },
   "devDependencies": {
-    "@playwright/test": "^1.35.0",
+    "@playwright/test": "^1.37.1",
     "@types/url-safe-base64": "^1.1.0",
     "eslint": "^8.2.0",
     "typescript": "^5.1.6",

--- a/packages/runtime/.gitignore
+++ b/packages/runtime/.gitignore
@@ -3,3 +3,6 @@ node_modules
 dist
 dist-ssr
 *.local
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/packages/runtime/lib/helpers.ts
+++ b/packages/runtime/lib/helpers.ts
@@ -1,4 +1,3 @@
-import { WASIFS } from "@runno/wasi";
 import { extractTarGz } from "./tar";
 
 export function stripWhitespace(text: string): string {
@@ -62,23 +61,7 @@ export function elementCodeContent(element: HTMLElement): string {
 export async function fetchWASIFS(fsURL: string) {
   const response = await fetch(fsURL);
   const buffer = await response.arrayBuffer();
-  const files = await extractTarGz(new Uint8Array(buffer));
-
-  const fs: WASIFS = {};
-  for (const file of files) {
-    fs[file.name] = {
-      path: file.name,
-      timestamps: {
-        change: new Date(file.lastModified),
-        access: new Date(file.lastModified),
-        modification: new Date(file.lastModified),
-      },
-      mode: "binary",
-      content: new Uint8Array(await file.arrayBuffer()),
-    };
-  }
-
-  return fs;
+  return await extractTarGz(new Uint8Array(buffer));
 }
 
 export function isErrorObject(

--- a/packages/runtime/lib/provider.ts
+++ b/packages/runtime/lib/provider.ts
@@ -102,8 +102,18 @@ export class RunnoProvider implements RuntimeMethods {
     this.terminal.terminal.clear();
 
     if (run.baseFSURL) {
-      const baseFS = await fetchWASIFS(run.baseFSURL);
-      fs = { ...fs, ...baseFS };
+      try {
+        const baseFS = await fetchWASIFS(run.baseFSURL);
+        fs = { ...fs, ...baseFS };
+      } catch (e) {
+        console.error(e);
+        this.terminal.terminal.write(`\nRunno crashed: ${e}\n`);
+
+        return {
+          resultType: "crash",
+          error: makeRunnoError(e),
+        };
+      }
     }
 
     return this.terminal.run(

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -64,7 +64,6 @@
     "@obsidize/tar-browserify": "^3.0.0",
     "@runno/host": "^0.5.1",
     "@runno/wasi": "^0.5.1",
-    "js-untar": "^2.0.0",
     "lit": "^2.7.6",
     "pako": "^1.0.11",
     "runno-codemirror-lang-ruby": "^0.0.2",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -31,6 +31,9 @@
   "scripts": {
     "dev": "vite",
     "watch": "vite build --watch",
+    "test:serve": "vite --config tests/vite.config.js",
+    "test:playwright": "playwright test",
+    "test": "npm run test:playwright",
     "build:docs": "typedoc --options typedoc.config.cjs",
     "build:package": "tsc --noEmit && vite build",
     "build": "npm run build:docs && npm run build:package",
@@ -38,6 +41,7 @@
     "lint": "npx eslint src"
   },
   "devDependencies": {
+    "@playwright/test": "^1.37.1",
     "@rollup/plugin-typescript": "^8.2.5",
     "eslint": "^7.28.0",
     "typedoc": "^0.24.8",
@@ -57,6 +61,7 @@
     "@codemirror/language": "^0.19.0",
     "@codemirror/rectangular-selection": "^0.19.2",
     "@codemirror/view": "^0.19.31",
+    "@obsidize/tar-browserify": "^3.0.0",
     "@runno/host": "^0.5.1",
     "@runno/wasi": "^0.5.1",
     "js-untar": "^2.0.0",

--- a/packages/runtime/playwright.config.ts
+++ b/packages/runtime/playwright.config.ts
@@ -1,0 +1,86 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: "./tests",
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: "html",
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: "http://localhost:5679",
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: "on-first-retry",
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+
+    // TODO: Playwright doesn't support Shared Array Buffer in Safari
+    // https://github.com/microsoft/playwright/issues/14043
+    //
+    // {
+    //   name: "webkit",
+    //   use: { ...devices["Desktop Safari"] },
+    // },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: [
+    {
+      command: "npm run test:serve",
+      port: 5679,
+    },
+    {
+      command: "cd ../website && npm run dev",
+      port: 4321,
+      reuseExistingServer: !process.env.CI,
+    },
+  ],
+});

--- a/packages/runtime/src/main.ts
+++ b/packages/runtime/src/main.ts
@@ -1,1 +1,6 @@
 import "../lib/main";
+import { headlessRunCode } from "../lib/main";
+
+globalThis.Runno = {
+  headlessRunCode,
+};

--- a/packages/runtime/tests/headless.spec.ts
+++ b/packages/runtime/tests/headless.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "@playwright/test";
+import { RunResult } from "@runno/host";
+
+// TODO: These are dependent on `@runno/website` being run on localhost:4321
+// See: https://github.com/taybenlor/runno/issues/258
+
+// TODO: This python test times out, I think because of the massive base tar file.
+// When I comment out the base FS it works fine.
+test.skip("a simple python example", async ({ page }) => {
+  await page.goto("/");
+
+  const result: RunResult = await page.evaluate(async () => {
+    return await globalThis.Runno.headlessRunCode(
+      "python",
+      `print("Hello, World!")`
+    );
+  });
+
+  expect(result.resultType).toBe("complete");
+  if (result.resultType !== "complete") throw new Error("wtf");
+  expect(result.stderr).toBe("");
+  expect(result.stdout).toBe("Hello, World!\n");
+});
+
+test("a simple ruby example", async ({ page }) => {
+  await page.goto("/");
+
+  const result: RunResult = await page.evaluate(async () => {
+    return await globalThis.Runno.headlessRunCode(
+      "ruby",
+      `puts "Hello, World!"`
+    );
+  });
+
+  expect(result.resultType).toBe("complete");
+  if (result.resultType !== "complete") throw new Error("wtf");
+  expect(result.stderr).toBe("");
+  expect(result.stdout).toBe("Hello, World!\n");
+});

--- a/packages/runtime/tests/vite.config.js
+++ b/packages/runtime/tests/vite.config.js
@@ -1,0 +1,20 @@
+import { defineConfig } from "vite";
+
+const crossOriginPolicy = {
+  name: "configure-server",
+
+  configureServer(server) {
+    server.middlewares.use((_req, res, next) => {
+      res.setHeader("Cross-Origin-Opener-Policy", "same-origin");
+      res.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
+      next();
+    });
+  },
+};
+
+export default defineConfig({
+  plugins: [crossOriginPolicy],
+  server: {
+    port: 5679,
+  },
+});

--- a/packages/wasi/package.json
+++ b/packages/wasi/package.json
@@ -40,7 +40,7 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "@playwright/test": "^1.26.1",
+    "@playwright/test": "^1.37.1",
     "typescript": "^5.1.6",
     "typedoc": "^0.24.8",
     "vite": "^4.4.9"


### PR DESCRIPTION
Fixes #253 

Adds a way to test `@runno/runtime` with playwright. Currently only includes tests for ruby. I tried testing python but it times out playwright trying to extract the filesystem. Which is weird because the client manages to pass a similar test successfully. Needs to be investigated further.