### PR TITLE
fix hang in headlessRunFS when reading stdin

### DIFF
--- a/packages/runtime/lib/headless.ts
+++ b/packages/runtime/lib/headless.ts
@@ -77,6 +77,7 @@ export async function headlessRunFS(
 
   if (stdin) {
     workerHost.pushStdin(stdin);
+    workerHost.pushEOF();
   }
 
   const result = await workerHost.start();


### PR DESCRIPTION
When I run `headlessRunCode` with the Ruby script `p readlines`, it hangs up by waiting for the end of the stdin.

In `runno-run`, reading stdin is stopped by pressing ctrl + D and sending EOF to the runtime. On the other hand, `headlessRunCode` gets the whole stdin and there is no way to send EOF to the runtime.

I am not sure this is a bug or an intentional design. If it is intentional, just close this PR.
Thank you.