### PR TITLE
docs: add syntax highlighting to various code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,20 +37,20 @@ The `@runno/runtime` is built on top of the primitives provided by `@runno/wasi`
 
 Start by adding `@runno/runtime` to your package:
 
-```
-$ npm install @runno/runtime
+```sh
+npm install @runno/runtime
 ```
 
 Import `@runno/runtime` in whatever place you'll be using the runno elements.
 The simplest is in your entrypoint file (e.g. `main.ts` or `index.ts`).
 
-```
+```js
 import '@runno/runtime';
 ```
 
 Once you've imported them you can use runno elements on the page.
 
-```
+```html
 <runno-run runtime="python" editor controls>
 print('Hello, World!')
 </runno-run>
@@ -81,7 +81,7 @@ The system supports a number of runtimes based on existing packages published to
 
 The runtime also provides a component for running WASI binaries directly.
 
-```
+```html
 <runno-wasi src="/ffmpeg.wasm" autorun></runno-wasi>
 ```
 
@@ -157,11 +157,11 @@ This repo is broken down into a few packages using [lerna](https://lerna.js.org/
 
 If you're lucky everything should work after doing:
 
-```
-$ npm install
-$ npm run bootstrap
-$ npm run build  # make sure the dependent libraries are built
-$ npm run dev
+```sh
+npm install
+npm run bootstrap
+npm run build  # make sure the dependent libraries are built
+npm run dev
 ```
 
 At that point you should be able to navigate to:
@@ -171,16 +171,16 @@ At that point you should be able to navigate to:
 
 If you're unlucky then you might have to run the two independently. In two different terminal sessions do:
 
-```
-$ cd packages/client
-$ npm run dev
+```sh
+cd packages/client
+npm run dev
 ```
 
 and
 
-```
-$ cd packages/website
-$ npm run dev
+```sh
+cd packages/website
+npm run dev
 ```
 
 If you edit `host`, `terminal`, `wasi` or `runtime` you will need to re-build them with `npm run build`.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -12,20 +12,20 @@ without using iframes.
 
 Start by adding `@runno/runtime` to your package:
 
-```
-$ npm install @runno/runtime
+```sh
+npm install @runno/runtime
 ```
 
 Import `@runno/runtime` in whatever place you'll be using the runno elements.
 The simplest is in your entrypoint file (e.g. `main.ts` or `index.ts`).
 
-```
+```js
 import '@runno/runtime';
 ```
 
 Once you've imported them you can use runno elements on the page.
 
-```
+```html
 <runno-run runtime="python" editor controls>
 print('Hello, World!')
 </runno-run>
@@ -44,14 +44,14 @@ These create a [cross-origin isolated context](https://web.dev/cross-origin-isol
 
 Runno supports a headless API.
 
-```
+```js
 import { headlessRunCode, headlessRunFS } from "@runno/runtime";
 ```
 
 You can use this headless API to run code in a particular language without
 having to use the DOM. For example:
 
-```
+```js
 const result = await headlessRunCode("python", "print('Hello World!')");
 ```
 

--- a/packages/wasi/README.md
+++ b/packages/wasi/README.md
@@ -245,13 +245,13 @@ This will build the test programs and download existing test suites.
 _You'll need to have cargo installed to run the tests_
 
 ```sh
-$ npm run test:prepare
+npm run test:prepare
 ```
 
 Then run the test suite:
 
 ```sh
-$ npm run test
+npm run test
 ```
 
 The test suite includes the following tests:


### PR DESCRIPTION
## Summary

Ensure all code blocks in the docs have syntax highlighting

## Details

- a few code blocks had syntax highlighting, but several were missing it
  - add it to all of them to improve readability

- also remove `$` in front of shell commands [per `markdownlint` `md014`](https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md014.md) and to make the blocks properly copiable

## Future Work

1. [ ] there's some other `markdownlint` violations as well
   - [ ] most notably, [per `md025`](https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md025.md), semantically there can only be one `h1` per page and some of the docs have multiple `h1`s