### PR TITLE
Async reactor API for WASI exports

### DIFF
--- a/packages/wasi/lib/main.ts
+++ b/packages/wasi/lib/main.ts
@@ -2,4 +2,5 @@ export * from "./types";
 export * from "./wasi/wasi";
 export * from "./wasi/wasi-context";
 export * from "./worker/wasi-host";
+export * from "./worker/wasi-reactor-host";
 export * as WASISnapshotPreview1 from "./wasi/snapshot-preview1";

--- a/packages/wasi/lib/types.ts
+++ b/packages/wasi/lib/types.ts
@@ -39,3 +39,43 @@ export type WASIExecutionResult = {
   exitCode: number;
   fs: WASIFS;
 };
+
+export type WASMArg = Int32 | Uint32 | string | Int32Array | Uint32Array;
+
+export class Int32 {
+  private _value: number = 0;
+  constructor(newValue: number) {
+    if (newValue < -2147483648 || 2147483647 < newValue) {
+      throw new TypeError("Number doesn't fit within range!");
+    }
+    this._value = newValue;
+  }
+  get value(): number {
+    return this._value;
+  }
+  set value(newValue: number) {
+    if (newValue < -2147483648 || 2147483647 < newValue) {
+      throw new TypeError("Number doesn't fit within range!");
+    }
+    this._value = newValue;
+  }
+}
+
+export class Uint32 {
+  private _value: number = 0;
+  constructor(newValue: number) {
+    if (newValue < 0 || 4294967295 < newValue) {
+      throw new TypeError("Number doesn't fit within range!");
+    }
+    this._value = newValue;
+  }
+  get value(): number {
+    return this._value;
+  }
+  set value(newValue: number) {
+    if (newValue < 0 || 4294967295 < newValue) {
+      throw new TypeError("Number doesn't fit within range!");
+    }
+    this._value = newValue;
+  }
+}

--- a/packages/wasi/lib/worker/wasi-reactor-host.ts
+++ b/packages/wasi/lib/worker/wasi-reactor-host.ts
@@ -1,0 +1,216 @@
+import { WASIContextOptions } from "../wasi/wasi-context";
+import {
+  WASMArgMessage,
+  HostMessage,
+  WorkerMessage,
+} from "./wasi-reactor-worker";
+import { WASMArg, Int32, Uint32 } from "../types";
+import WASIReactorWorker from "./wasi-reactor-worker?worker&inline";
+
+function sendMessage(worker: Worker, message: WorkerMessage) {
+  worker.postMessage(message);
+}
+
+// (export function names) => (worker promises)
+type Exports = Record<string, Function>;
+type Callbacks = Record<number, { resolve: Function; reject: Function }>;
+type WASIWorkerHostContext = Partial<Omit<WASIContextOptions, "stdin">>;
+
+export class WASIReactorWorkerHost {
+  binaryURL: string;
+  context: WASIWorkerHostContext;
+
+  worker!: Worker;
+  exports: Exports = {};
+  memory_start_index: number;
+
+  callbacks: Callbacks = {};
+
+  constructor(
+    binaryURL: string,
+    memory_start_index: number = 0,
+    context: WASIWorkerHostContext,
+    errorHandler: (err: any) => void
+  ) {
+    this.binaryURL = binaryURL;
+    this.memory_start_index = memory_start_index;
+    this.context = context;
+    window.addEventListener("unhandledrejection", (event) =>
+      errorHandler(event.reason)
+    );
+  }
+
+  initialize() {
+    return new Promise<void>((resolve, _) => {
+      this.worker = new WASIReactorWorker();
+      this.worker.addEventListener("message", (messageEvent) => {
+        const message: HostMessage = messageEvent.data;
+        switch (message.type) {
+          case "stdout":
+            this.context.stdout?.(message.text);
+            break;
+          case "stderr":
+            this.context.stderr?.(message.text);
+            break;
+          case "debug":
+            this.context.debug?.(
+              message.name,
+              message.args,
+              message.ret,
+              message.data
+            );
+            break;
+          case "initialized":
+            message.exports.forEach((func_name: any, id: number) => {
+              if (func_name === "memory") {
+                return;
+              }
+              this.exports[func_name] = (...args: WASMArg[]) => {
+                let typed_args: WASMArgMessage[] = [];
+                args.forEach((arg: WASMArg) => {
+                  let arg_type: any;
+                  switch (true) {
+                    case arg instanceof Int32:
+                      arg_type = "Int32";
+                      break;
+                    case arg instanceof Uint32:
+                      arg_type = "Uint32";
+                      break;
+                    case typeof arg === "string":
+                      arg_type = "string";
+                      break;
+                    case arg instanceof Int32Array:
+                      arg_type = "Int32Array";
+                      break;
+                    case arg instanceof Uint32Array:
+                      arg_type = "Uint32Array";
+                      break;
+                  }
+                  typed_args.push({ type: arg_type, data: arg });
+                });
+                return new Promise((resolve, reject) => {
+                  sendMessage(this.worker, {
+                    target: "client",
+                    type: "call",
+                    call_id: id,
+                    method: func_name,
+                    args: typed_args,
+                  });
+                  this.callbacks[id] = {
+                    resolve: resolve,
+                    reject: reject,
+                  };
+                });
+              };
+            });
+            resolve();
+            break;
+          case "result":
+            if (message.err_code === 0) {
+              let ret_vals: any[] = [];
+              let offset: number = this.memory_start_index;
+              while (true) {
+                // arg_length includes any bits used for tagging and length storing
+                const [arg, new_offset] = this.parseArg(offset, message.memory);
+                if (arg === null) {
+                  break;
+                }
+                ret_vals.push(arg);
+                offset = new_offset;
+              }
+
+              this.callbacks[message.call_id].resolve(ret_vals);
+            } else {
+              this.callbacks[message.call_id].reject(message.err_code);
+            }
+
+            // Wipe memory buffer for next export call
+            const buffer = new Uint8Array(
+              message.memory,
+              this.memory_start_index,
+              length
+            );
+            buffer.fill(0);
+            break;
+        }
+      });
+
+      sendMessage(this.worker, {
+        target: "client",
+        type: "initialize",
+        binaryURL: this.binaryURL,
+        memory_start_index: this.memory_start_index,
+        args: this.context.args,
+        env: this.context.env,
+        fs: this.context.fs,
+        isTTY: this.context.isTTY,
+      });
+    });
+  }
+
+  parseArg(start_index: number, memory: SharedArrayBuffer): [any, number] {
+    const view = new DataView(memory);
+    const little_endian = true;
+
+    const tag = view.getInt8(start_index);
+    start_index += 1;
+
+    let arg;
+    switch (tag) {
+      case -1:
+        arg = null;
+        break;
+      case 1:
+        arg = view.getInt32(start_index, little_endian);
+        start_index += 4;
+        break;
+      case 2:
+        arg = view.getUint32(start_index, little_endian);
+        start_index += 4;
+        break;
+      case 3:
+        const str_length = view.getUint32(start_index, little_endian);
+        start_index += 4;
+
+        const str_buffer = new Uint8Array(memory, start_index, str_length);
+        start_index += str_length;
+
+        arg = new TextDecoder().decode(str_buffer);
+        break;
+      case 4:
+        const i32_length = view.getUint32(start_index, little_endian);
+        start_index += 4;
+
+        let i32_buffer = [];
+        let i32_i = 0;
+        while (i32_i < i32_length) {
+          i32_buffer.push(view.getInt32(start_index, little_endian));
+          i32_i += 1;
+          start_index += 4;
+        }
+
+        arg = new Int32Array(i32_buffer);
+        break;
+      case 5:
+        const u32_length = view.getUint32(start_index, little_endian);
+        start_index += 4;
+
+        let u32_buffer = [];
+        let u32_i = 0;
+        while (u32_i < u32_length) {
+          u32_buffer.push(view.getUint32(start_index, little_endian));
+          u32_i += 1;
+          start_index += 4;
+        }
+
+        arg = new Uint32Array(u32_buffer);
+        break;
+      default:
+        throw new TypeError(
+          `Unsupported Type Read From Buffer: ${tag}, ${start_index}!`
+        );
+    }
+
+    return [arg, start_index];
+  }
+}

--- a/packages/wasi/lib/worker/wasi-reactor-worker.ts
+++ b/packages/wasi/lib/worker/wasi-reactor-worker.ts
@@ -1,0 +1,297 @@
+import { WASI } from "../wasi/wasi";
+import { WASIContextOptions, WASIContext } from "../wasi/wasi-context";
+import { WASMArg } from "../types";
+
+type WorkerWASIContext = Partial<
+  Omit<WASIContextOptions, "stdin" | "stdout" | "stderr" | "debug">
+>;
+
+export type WASMArgMessage = {
+  type: "Int32" | "Uint32" | "string" | "Int32Array" | "Uint32Array";
+  data: WASMArg;
+};
+
+type InitializeWorkerMessage = {
+  target: "client";
+  type: "initialize";
+  binaryURL: string;
+  memory_start_index: number;
+} & WorkerWASIContext;
+
+type CallWorkerMessage = {
+  target: "client";
+  type: "call";
+  call_id: number;
+  method: any;
+  args: WASMArgMessage[];
+};
+
+export type WorkerMessage = InitializeWorkerMessage | CallWorkerMessage;
+
+type InitializedHostMessage = {
+  target: "host";
+  type: "initialized";
+  // TODO Make these types stricter
+  exports: any;
+};
+
+type StdoutHostMessage = {
+  target: "host";
+  type: "stdout";
+  text: string;
+};
+
+type StderrHostMessage = {
+  target: "host";
+  type: "stderr";
+  text: string;
+};
+
+type DebugHostMessage = {
+  target: "host";
+  type: "debug";
+  name: string;
+  args: string[];
+  ret: number;
+  data: { [key: string]: any }[];
+};
+
+type ResultHostMessage = {
+  target: "host";
+  type: "result";
+  call_id: number;
+  memory: SharedArrayBuffer;
+  err_code: number;
+};
+
+type CrashHostMessage = {
+  target: "host";
+  type: "crash";
+  error: {
+    message: string;
+    type: string;
+  };
+};
+
+export type HostMessage =
+  | InitializedHostMessage
+  | StdoutHostMessage
+  | StderrHostMessage
+  | DebugHostMessage
+  | ResultHostMessage
+  | CrashHostMessage;
+
+let exports: any;
+let memory_start_index: number;
+
+onmessage = async (ev: MessageEvent) => {
+  const data = ev.data as WorkerMessage;
+
+  switch (data.type) {
+    case "initialize":
+      exports = await WASI.initialize(
+        fetch(data.binaryURL),
+        new WASIContext({
+          stdout: sendStdout,
+          stderr: sendStderr,
+        })
+      );
+      memory_start_index = data.memory_start_index;
+      sendMessage({
+        target: "host",
+        type: "initialized",
+        exports: Object.keys(exports),
+      });
+      break;
+    case "call":
+      let new_arg_index: number = memory_start_index;
+      data.args.forEach((arg: WASMArgMessage) => {
+        new_arg_index = parseArg(arg, new_arg_index);
+      });
+
+      // Mark end of arguments list with -1
+      const view = new DataView(exports.memory.buffer);
+      view.setUint8(new_arg_index, -1);
+      new_arg_index += 1;
+
+      const err_code = exports[data.method].apply(null, []);
+
+      sendMessage({
+        target: "host",
+        type: "result",
+        call_id: data.call_id,
+        memory: exports.memory.buffer,
+        err_code: err_code,
+      });
+  }
+};
+
+function parseArg(arg: any, start_index: number) {
+  // "arg" should be typed as WASMArgMessage however casting the inner
+  // WASMArg to Int32 or Uint32 is undefined for some reason
+  // For functionality, typing will be forgoed so that _value's can be passed
+  switch (arg.type) {
+    case "Int32":
+      return storeInt32(arg.data._value, exports.memory.buffer, start_index);
+      break;
+    case "Uint32":
+      return storeUint32(arg.data._value, exports.memory.buffer, start_index);
+      break;
+    case "string":
+      return storeString(
+        arg.data as string,
+        exports.memory.buffer,
+        start_index
+      );
+      break;
+    case "Int32Array":
+      return storeInt32Array(
+        arg.data as Int32Array,
+        exports.memory.buffer,
+        start_index
+      );
+      break;
+    case "Uint32Array":
+      return storeUint32Array(
+        arg.data as Uint32Array,
+        exports.memory.buffer,
+        start_index
+      );
+      break;
+    default:
+      throw new TypeError(`Unsupported Type Given: ${arg.type}!`);
+  }
+}
+
+const tag_offset: number = 1;
+
+function storeInt32(
+  arg: number,
+  memory: SharedArrayBuffer,
+  start_index: number
+) {
+  // 0-1   byte  => tag of 0 for Int32 (i8)
+  // 1-5   bytes => data               (i32)
+  const view = new DataView(memory);
+  view.setInt8(start_index, 1);
+  view.setInt32(start_index + tag_offset, arg, true);
+
+  const data_offset = 4;
+  return start_index + tag_offset + data_offset;
+}
+
+function storeUint32(
+  arg: number,
+  memory: SharedArrayBuffer,
+  start_index: number
+) {
+  // 0-1   byte  => tag of 1 for Uint64 (i8)
+  // 1-5   bytes => data                (u32)
+  const view = new DataView(memory);
+  view.setInt8(start_index, 2);
+  view.setUint32(start_index + tag_offset, arg, true);
+
+  const data_offset = 4;
+  return start_index + tag_offset + data_offset;
+}
+
+function storeString(
+  arg: string,
+  memory: SharedArrayBuffer,
+  start_index: number
+) {
+  // 0-1             byte  => tag of 2 for string (i8)
+  // 1-5             bytes => length of string    (u32)
+  // 5-(5+n)         bytes => string data         (u8)
+  const len_offset = 4;
+
+  const view = new DataView(memory);
+  view.setInt8(start_index, 3);
+
+  const encodedText = new TextEncoder().encode(arg);
+  const length = encodedText.byteLength;
+  view.setUint32(start_index + tag_offset, length, true);
+
+  const buffer = new Uint8Array(
+    memory,
+    start_index + tag_offset + len_offset,
+    length
+  );
+  buffer.set(encodedText);
+
+  return start_index + tag_offset + len_offset + length;
+}
+
+function storeInt32Array(
+  arg: Int32Array,
+  memory: SharedArrayBuffer,
+  start_index: number
+) {
+  // 0-1               byte  => tag of 3 for Int32Array (i8)
+  // 1-5               bytes => length of array         (u32)
+  // 5-(5+n*4)         bytes => array data              (i32)
+  const len_offset = 4;
+
+  const view = new DataView(memory);
+  view.setInt8(start_index, 4);
+  view.setUint32(start_index + tag_offset, arg.byteLength / 4, true);
+
+  let data_offset = 0;
+  for (const i32 of arg) {
+    view.setInt32(
+      start_index + tag_offset + len_offset + data_offset,
+      i32,
+      true
+    );
+    data_offset += 4;
+  }
+
+  return start_index + tag_offset + len_offset + data_offset;
+}
+
+function storeUint32Array(
+  arg: Uint32Array,
+  memory: SharedArrayBuffer,
+  start_index: number
+) {
+  // 0-1         byte  => tag of 4 for Uint64Array (i8)
+  // 1-5         bytes => length of array          (u32)
+  // 5-(5+n*8)   bytes => array data               (u64)
+  const len_offset = 4;
+
+  const view = new DataView(memory);
+  view.setInt8(start_index, 5);
+  view.setUint32(start_index + tag_offset, arg.byteLength / 4, true);
+
+  let data_offset = 0;
+  for (const u32 of arg) {
+    view.setUint32(
+      start_index + tag_offset + len_offset + data_offset,
+      u32,
+      true
+    );
+    data_offset += 4;
+  }
+
+  return start_index + tag_offset + len_offset + data_offset;
+}
+
+function sendMessage(message: HostMessage) {
+  postMessage(message);
+}
+
+function sendStdout(out: string) {
+  sendMessage({
+    target: "host",
+    type: "stdout",
+    text: out,
+  });
+}
+
+function sendStderr(err: string) {
+  sendMessage({
+    target: "host",
+    type: "stderr",
+    text: err,
+  });
+}


### PR DESCRIPTION
The goal of this API is to merge the functionality of both the `WASIReactor` and the `WASIWorkerHost` by having all `WASI` exports be wrapped as a `Promise` so long-running function calls won't halt any functionality in the main context. In addition, the API enforces a specification for how export argument data is handled by the `WASIReactorWorkerHost` so that the underlying `WebWorker` can pass arguments to any `WASI` export with type safety on the following types: `Int32`, `Uint32`, `string`, `Int32Array`, `Uint32Array`. It achieves this by tagging all arguments with a distinct type tag as they're stored in the `WASI` memory buffer (`exports.memory.buffer`). The exported `WASI` function will then need to parse the memory buffer for those arguments and repeat the same process for any values it would like to return.

![image](https://github.com/user-attachments/assets/7a0e7963-e4f8-42af-b30d-0676262fe10a)

Depicted above is a sample implementation showcasing how to call an export. The parameters for constructing the `WASIReactorWorkerHost` slightly vary compared to `WASIReactor` and `WASIWorkerHost` by enforcing a start index in the memory buffer for which all arguments should begin storing data (the `8`) as well as an error handler function for the error code that should be returned by the exported function.

This specification is quite terse and enforces a lot of work to be done by the `WASM` binary creator to ensure the binary is properly reading from the memory the way the API is storing it. However with well laid out documentation, I still think this approach is quite effective overall and establishes good calling conventions that developers should abide until the `WASM` standard is able to support more diverse types.