### PR TITLE
feat(sandbox): support streaming stdin in runFS

### DIFF
--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -23,7 +23,11 @@ Executes a code snippet in the specified runtime environment.
 - `runtime`: The runtime environment to use (e.g., "python", "quickjs", "sqlite", "clang", "clangpp", "ruby", "php-cgi")
 - `code`: The code string to execute
 - `options`: Optional configuration:
-  - `stdin`: Input to be passed to the standard input
+  - `stdin`: Input to be passed to the standard input. Supports:
+    - `string`: Plain text input
+    - `AsyncIterable<string>`: Asynchronous stream of chunks
+    - `ReadableStream<string>`: Web Streams API stream
+    - `() => AsyncIterable<string> | ReadableStream<string>`: Factory function to prevent premature execution
   - `timeout`: Maximum execution time in seconds
 
 **Returns:** A Promise that resolves to a `RunResult`, which could be:
@@ -52,7 +56,7 @@ Executes code from a virtual filesystem in the specified runtime environment.
 - `entryPath`: The path to the entry file in the filesystem
 - `fs`: A WASI filesystem structure defining files and directories
 - `options`: Optional configuration:
-  - `stdin`: Input to be passed to the standard input
+  - `stdin`: Input to be passed to the standard input. Supports `string`, `AsyncIterable<string>`, `ReadableStream<string>`, or a factory function.
   - `timeout`: Maximum execution time in seconds
 
 **Returns:** A Promise that resolves to a `RunResult` (same structure as `runCode`)
@@ -114,6 +118,22 @@ const completeFS = {
 
 const result = await runFS("python", "/myprogram.py", completeFS);
 console.log(result.stdout);
+```
+
+### Streaming stdin
+
+You can stream input to a running sandbox using an `AsyncIterable` or `ReadableStream`. This is useful for interactive programs or processing large amounts of data without loading it all into memory.
+
+```javascript
+async function* inputSource() {
+  yield "first line\n";
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  yield "second line\n";
+}
+
+const result = await runCode("python", "import sys; print(sys.stdin.read())", {
+  stdin: inputSource(),
+});
 ```
 
 ## Supported Runtimes

--- a/packages/sandbox/__tests__/runtime/streaming-stdin.test.ts
+++ b/packages/sandbox/__tests__/runtime/streaming-stdin.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { runFS } from "@runno/sandbox";
 import type { WASIFS } from "@runno/wasi";
 
-describe("@runno/sandbox streaming stdin", () => {
+describe("@runno/sandbox streaming stdin", { timeout: 30000 }, () => {
   let testFS: WASIFS;
 
   beforeEach(() => {
@@ -181,9 +181,25 @@ for line in sys.stdin:
 
   describe("Backward compatibility", () => {
     it("should still accept plain string stdin", async () => {
-      const result = await runFS("python", "/program.py", testFS, {
-        stdin: "backward_compat\n",
-      });
+      const result = await runFS(
+        "python",
+        "/program.py",
+        {
+          "/program.py": {
+            path: "program.py",
+            content: `print(f"Got: {input()}")`,
+            mode: "string",
+            timestamps: {
+              access: new Date(),
+              modification: new Date(),
+              change: new Date(),
+            },
+          },
+        },
+        {
+          stdin: "backward_compat\n",
+        },
+      );
 
       expect(result.resultType).toBe("complete");
       if (result.resultType === "complete") {
@@ -398,7 +414,10 @@ for line in sys.stdin:
         // Check that output file was created
         expect(result.fs["/output.txt"]).toBeDefined();
         if (result.fs["/output.txt"]) {
-          const content = result.fs["/output.txt"].content as string;
+          let content = result.fs["/output.txt"].content;
+          if (content instanceof Uint8Array) {
+            content = new TextDecoder().decode(content);
+          }
           expect(content).toContain("Processed: data1");
           expect(content).toContain("Processed: data2");
         }
@@ -435,6 +454,130 @@ for line in sys.stdin:
       expect(result2.resultType).toBe("complete");
       if (result2.resultType === "complete") {
         expect(result2.stdout).toContain("Got: second");
+      }
+    });
+  });
+
+  describe("Edge Case: Timeout & Errors", () => {
+    it("should respect timeout when using streaming input", async () => {
+      async function* infiniteStream() {
+        while (true) {
+          yield "still going...\n";
+          await new Promise((resolve) => setTimeout(resolve, 10));
+        }
+      }
+
+      const result = await runFS("python", "/program.py", testFS, {
+        stdin: () => infiniteStream(),
+        timeout: 0.2,
+      });
+      expect(result.resultType).toBe("timeout");
+    });
+
+    it("should handle errors in the input stream", async () => {
+      async function* errorStream() {
+        yield "part 1\n";
+        throw new Error("Stream exploded");
+      }
+
+      const result = await runFS("python", "/program.py", testFS, {
+        stdin: errorStream(),
+      });
+
+      // It should either be a complete result (if program finished fast) or a crash
+      if (result.resultType === "crash") {
+        expect(result.error.message).toContain("Stream exploded");
+      } else {
+        expect(result.resultType).toBe("complete");
+      }
+    });
+
+    it("should handle extremely large string stdin via unified chunking", async () => {
+      // Create a 100KB string to exceed the 8KB buffer many times
+      const massiveString = "A".repeat(100 * 1024) + "\n";
+      const result = await runFS("python", "/program.py", testFS, {
+        stdin: massiveString,
+      });
+
+      expect(result.resultType).toBe("complete");
+      if (result.resultType === "complete") {
+        expect(result.stdout).toContain("Got: ");
+        expect(result.exitCode).toBe(0);
+      }
+    });
+
+    it("should handle slow consumer and backpressure", async () => {
+      // Create a program that reads input slowly using a busy loop
+      const slowFS: WASIFS = {
+        "/program.py": {
+          path: "program.py",
+          content: `
+import sys
+def busy_wait(iterations):
+    # Just a simple loop to consume CPU time
+    for _ in range(iterations):
+        pass
+for line in sys.stdin:
+    # Use a busy loop instead of time.sleep to simulate slow processing
+    busy_wait(100000)
+    print(f"Read: {line.strip()}")
+`,
+          mode: "string",
+          timestamps: {
+            access: new Date(),
+            modification: new Date(),
+            change: new Date(),
+          },
+        },
+      };
+
+      async function* fastStream() {
+        for (let i = 0; i < 20; i++) {
+          yield `line${i}\n`; // Produce faster than it can be consumed
+        }
+      }
+
+      const result = await runFS("python", "/program.py", slowFS, {
+        stdin: fastStream(),
+      });
+
+      expect(result.resultType).toBe("complete");
+      if (result.resultType === "complete") {
+        expect(result.stdout).toContain("Read: line19");
+        expect(result.exitCode).toBe(0);
+      }
+    });
+
+    it("should handle empty chunks within stream", async () => {
+      async function* withEmpty() {
+        yield "a\n";
+        yield "";
+        yield "";
+        yield "b\n";
+      }
+      const result = await runFS("python", "/program.py", testFS, {
+        stdin: withEmpty(),
+      });
+      expect(result.resultType).toBe("complete");
+      if (result.resultType === "complete") {
+        expect(result.stdout).toContain("Got: a");
+        expect(result.stdout).toContain("Got: b");
+      }
+    });
+
+    it("should support factory functions returning ReadableStream", async () => {
+      const result = await runFS("python", "/program.py", testFS, {
+        stdin: () =>
+          new ReadableStream<string>({
+            start(controller) {
+              controller.enqueue("factory_stream\n");
+              controller.close();
+            },
+          }),
+      });
+      expect(result.resultType).toBe("complete");
+      if (result.resultType === "complete") {
+        expect(result.stdout).toContain("Got: factory_stream");
       }
     });
   });

--- a/packages/sandbox/__tests__/runtime/streaming-stdin.test.ts
+++ b/packages/sandbox/__tests__/runtime/streaming-stdin.test.ts
@@ -1,0 +1,441 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { runFS } from "@runno/sandbox";
+import type { WASIFS } from "@runno/wasi";
+
+describe("@runno/sandbox streaming stdin", () => {
+  let testFS: WASIFS;
+
+  beforeEach(() => {
+    // Create a simple Python program that reads from stdin and echoes it back
+    testFS = {
+      "/program.py": {
+        path: "program.py",
+        content: `import sys
+for line in sys.stdin:
+    print(f"Got: {line.rstrip()}")
+`,
+        mode: "string",
+        timestamps: {
+          access: new Date(),
+          modification: new Date(),
+          change: new Date(),
+        },
+      },
+    };
+  });
+
+  describe("AsyncIterable<string>", () => {
+    it("should handle small chunks via async generator", async () => {
+      async function* smallChunks() {
+        yield "hello\n";
+        yield "world\n";
+      }
+
+      const result = await runFS("python", "/program.py", testFS, {
+        stdin: smallChunks(),
+      });
+
+      expect(result.resultType).toBe("complete");
+      if (result.resultType === "complete") {
+        expect(result.stdout).toContain("Got: hello");
+        expect(result.stdout).toContain("Got: world");
+        expect(result.exitCode).toBe(0);
+      }
+    });
+
+    it("should handle large chunks that exceed buffer size", async () => {
+      // Generate a chunk larger than 8KiB (default stdinBuffer size)
+      // Default buffer is 8192 bytes, minus 4 bytes header = 8188 usable
+      // Let's create ~20KB string to test splitting
+      const largeString = "x".repeat(20000) + "\n";
+
+      async function* largeChunks() {
+        yield largeString;
+      }
+
+      const result = await runFS("python", "/program.py", testFS, {
+        stdin: largeChunks(),
+      });
+
+      expect(result.resultType).toBe("complete");
+      if (result.resultType === "complete") {
+        expect(result.stdout).toContain("Got: ");
+        // The output should contain at least some of the x's
+        expect(result.stdout.length).toBeGreaterThan(100);
+        expect(result.exitCode).toBe(0);
+      }
+    });
+
+    it("should handle UTF-8 multi-byte characters correctly", async () => {
+      async function* utf8Chunks() {
+        // Mix of ASCII and multi-byte UTF-8 characters
+        yield "Hello\n";
+        yield "你好世界\n"; // Chinese: "Hello World"
+        yield "Привет\n"; // Russian: "Hello"
+        yield "🌍🚀\n"; // Emojis (4-byte UTF-8)
+      }
+
+      const result = await runFS("python", "/program.py", testFS, {
+        stdin: utf8Chunks(),
+      });
+
+      expect(result.resultType).toBe("complete");
+      if (result.resultType === "complete") {
+        expect(result.stdout).toContain("Got: Hello");
+        expect(result.stdout).toContain("Got: 你好世界");
+        expect(result.stdout).toContain("Got: Привет");
+        expect(result.stdout).toContain("Got: 🌍🚀");
+        expect(result.exitCode).toBe(0);
+      }
+    });
+
+    it("should handle async delays between chunks", async () => {
+      async function* delayedChunks() {
+        yield "first\n";
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        yield "second\n";
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        yield "third\n";
+      }
+
+      const result = await runFS("python", "/program.py", testFS, {
+        stdin: delayedChunks(),
+      });
+
+      expect(result.resultType).toBe("complete");
+      if (result.resultType === "complete") {
+        expect(result.stdout).toContain("Got: first");
+        expect(result.stdout).toContain("Got: second");
+        expect(result.stdout).toContain("Got: third");
+        expect(result.exitCode).toBe(0);
+      }
+    });
+  });
+
+  describe("ReadableStream<string>", () => {
+    it("should handle ReadableStream input", async () => {
+      const stream = new ReadableStream<string>({
+        start(controller) {
+          controller.enqueue("line1\n");
+          controller.enqueue("line2\n");
+          controller.enqueue("line3\n");
+          controller.close();
+        },
+      });
+
+      const result = await runFS("python", "/program.py", testFS, {
+        stdin: stream,
+      });
+
+      expect(result.resultType).toBe("complete");
+      if (result.resultType === "complete") {
+        expect(result.stdout).toContain("Got: line1");
+        expect(result.stdout).toContain("Got: line2");
+        expect(result.stdout).toContain("Got: line3");
+        expect(result.exitCode).toBe(0);
+      }
+    });
+
+    it("should handle ReadableStream with large chunk", async () => {
+      const largeString = "a".repeat(20000);
+      const stream = new ReadableStream<string>({
+        start(controller) {
+          controller.enqueue(largeString + "\n");
+          controller.close();
+        },
+      });
+
+      const result = await runFS("python", "/program.py", testFS, {
+        stdin: stream,
+      });
+
+      expect(result.resultType).toBe("complete");
+      if (result.resultType === "complete") {
+        expect(result.stdout).toContain("Got: ");
+        expect(result.exitCode).toBe(0);
+      }
+    });
+  });
+
+  describe("Factory function returning AsyncIterable", () => {
+    it("should handle factory function that returns async generator", async () => {
+      function createStdinIterator(): AsyncIterable<string> {
+        return (async function* () {
+          yield "foo\n";
+          yield "bar\n";
+        })();
+      }
+
+      const result = await runFS("python", "/program.py", testFS, {
+        stdin: createStdinIterator,
+      });
+
+      expect(result.resultType).toBe("complete");
+      if (result.resultType === "complete") {
+        expect(result.stdout).toContain("Got: foo");
+        expect(result.stdout).toContain("Got: bar");
+        expect(result.exitCode).toBe(0);
+      }
+    });
+  });
+
+  describe("Backward compatibility", () => {
+    it("should still accept plain string stdin", async () => {
+      const result = await runFS("python", "/program.py", testFS, {
+        stdin: "backward_compat\n",
+      });
+
+      expect(result.resultType).toBe("complete");
+      if (result.resultType === "complete") {
+        expect(result.stdout).toContain("Got: backward_compat");
+        expect(result.exitCode).toBe(0);
+      }
+    });
+
+    it("should work with undefined stdin", async () => {
+      const echoFS: WASIFS = {
+        "/program.py": {
+          path: "program.py",
+          content: `print("No input needed")`,
+          mode: "string",
+          timestamps: {
+            access: new Date(),
+            modification: new Date(),
+            change: new Date(),
+          },
+        },
+      };
+
+      const result = await runFS("python", "/program.py", echoFS, {
+        stdin: undefined,
+      });
+
+      expect(result.resultType).toBe("complete");
+      if (result.resultType === "complete") {
+        expect(result.stdout).toContain("No input needed");
+        expect(result.exitCode).toBe(0);
+      }
+    });
+  });
+
+  describe("UTF-8 boundary safety", () => {
+    it("should not split multi-byte UTF-8 sequences", async () => {
+      // Create a program that counts input characters
+      const countFS: WASIFS = {
+        "/program.py": {
+          path: "program.py",
+          content: `import sys
+content = sys.stdin.read()
+print(f"Chars: {len(content)}")
+print(f"Content: {repr(content)}")
+`,
+          mode: "string",
+          timestamps: {
+            access: new Date(),
+            modification: new Date(),
+            change: new Date(),
+          },
+        },
+      };
+
+      // String with many multi-byte characters that will force splitting
+      // Create 2000 Chinese characters (each is 3 bytes in UTF-8)
+      const chineseChars = "你".repeat(2000) + "好\n";
+
+      async function* chunks() {
+        yield chineseChars;
+      }
+
+      const result = await runFS("python", "/program.py", countFS, {
+        stdin: chunks(),
+      });
+
+      expect(result.resultType).toBe("complete");
+      if (result.resultType === "complete") {
+        // Python should be able to read the content without replacement characters
+        expect(result.stdout).not.toContain("\\ufffd"); // Unicode replacement character
+        expect(result.exitCode).toBe(0);
+      }
+    });
+
+    it("should handle 4-byte UTF-8 emoji characters at boundaries", async () => {
+      const countFS: WASIFS = {
+        "/program.py": {
+          path: "program.py",
+          content: `import sys
+content = sys.stdin.read()
+# Just echo back to verify no corruption
+print(repr(content))
+`,
+          mode: "string",
+          timestamps: {
+            access: new Date(),
+            modification: new Date(),
+            change: new Date(),
+          },
+        },
+      };
+
+      // Emojis are 4 bytes in UTF-8, good test for boundary cases
+      const emojiString = "🌍🚀🎉🔥💯".repeat(1000) + "\n";
+
+      async function* chunks() {
+        yield emojiString;
+      }
+
+      const result = await runFS("python", "/program.py", countFS, {
+        stdin: chunks(),
+      });
+
+      expect(result.resultType).toBe("complete");
+      if (result.resultType === "complete") {
+        expect(result.exitCode).toBe(0);
+      }
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("should handle empty async iterable", async () => {
+      async function* emptyChunks() {
+        // yield nothing
+      }
+
+      const result = await runFS("python", "/program.py", testFS, {
+        stdin: emptyChunks(),
+      });
+
+      expect(result.resultType).toBe("complete");
+      if (result.resultType === "complete") {
+        // Should exit cleanly with no output (program reads nothing and exits)
+        expect(result.exitCode).toBe(0);
+      }
+    });
+
+    it("should handle single large chunk without intermediate yields", async () => {
+      async function* singleLargeChunk() {
+        yield "x".repeat(50000) + "\n";
+      }
+
+      const result = await runFS("python", "/program.py", testFS, {
+        stdin: singleLargeChunk(),
+      });
+
+      expect(result.resultType).toBe("complete");
+      if (result.resultType === "complete") {
+        expect(result.exitCode).toBe(0);
+      }
+    });
+
+    it("should handle very rapid chunk generation", async () => {
+      async function* rapidChunks() {
+        for (let i = 0; i < 100; i++) {
+          yield `line${i}\n`;
+        }
+      }
+
+      const result = await runFS("python", "/program.py", testFS, {
+        stdin: rapidChunks(),
+      });
+
+      expect(result.resultType).toBe("complete");
+      if (result.resultType === "complete") {
+        // Check that at least some lines were processed
+        expect(result.stdout).toContain("Got: line0");
+        expect(result.exitCode).toBe(0);
+      }
+    });
+
+    it("should handle chunks with newlines and special characters", async () => {
+      async function* specialChunks() {
+        yield "line with\ttab\n";
+        yield "line with\\backslash\n";
+        yield 'line with "quotes"\n';
+        yield "line with\x00null\n"; // null character
+      }
+
+      const result = await runFS("python", "/program.py", testFS, {
+        stdin: specialChunks(),
+      });
+
+      expect(result.resultType).toBe("complete");
+      if (result.resultType === "complete") {
+        expect(result.exitCode).toBe(0);
+      }
+    });
+  });
+
+  describe("RunFS with streaming stdin and filesystem", () => {
+    it("should combine streaming stdin with virtual filesystem", async () => {
+      const combinedFS: WASIFS = {
+        "/program.py": {
+          path: "program.py",
+          content: `import sys
+# Read from stdin
+for line in sys.stdin:
+    with open('/output.txt', 'a') as f:
+        f.write(f"Processed: {line}")
+`,
+          mode: "string",
+          timestamps: {
+            access: new Date(),
+            modification: new Date(),
+            change: new Date(),
+          },
+        },
+      };
+
+      async function* chunks() {
+        yield "data1\n";
+        yield "data2\n";
+      }
+
+      const result = await runFS("python", "/program.py", combinedFS, {
+        stdin: chunks(),
+      });
+
+      expect(result.resultType).toBe("complete");
+      if (result.resultType === "complete") {
+        // Check that output file was created
+        expect(result.fs["/output.txt"]).toBeDefined();
+        if (result.fs["/output.txt"]) {
+          const content = result.fs["/output.txt"].content as string;
+          expect(content).toContain("Processed: data1");
+          expect(content).toContain("Processed: data2");
+        }
+        expect(result.exitCode).toBe(0);
+      }
+    });
+  });
+
+  describe("Multiple streaming operations in sequence", () => {
+    it("should handle multiple sequential calls with streaming stdin", async () => {
+      async function* firstChunks() {
+        yield "first\n";
+      }
+
+      async function* secondChunks() {
+        yield "second\n";
+      }
+
+      // First call
+      const result1 = await runFS("python", "/program.py", testFS, {
+        stdin: firstChunks(),
+      });
+
+      expect(result1.resultType).toBe("complete");
+      if (result1.resultType === "complete") {
+        expect(result1.stdout).toContain("Got: first");
+      }
+
+      // Second call
+      const result2 = await runFS("python", "/program.py", testFS, {
+        stdin: secondChunks(),
+      });
+
+      expect(result2.resultType).toBe("complete");
+      if (result2.resultType === "complete") {
+        expect(result2.stdout).toContain("Got: second");
+      }
+    });
+  });
+});

--- a/packages/sandbox/lib/host.ts
+++ b/packages/sandbox/lib/host.ts
@@ -21,6 +21,7 @@ export class WASIWorkerHost {
   result?: Promise<WASIExecutionResult>;
   worker?: Worker;
   reject?: (reason?: unknown) => void;
+  isRunning: boolean = false;
 
   constructor(binaryURL: string, context: WASIWorkerHostContext) {
     this.binaryURL = binaryURL;
@@ -32,6 +33,7 @@ export class WASIWorkerHost {
       throw new Error("WASIWorker Host can only be started once");
     }
 
+    this.isRunning = true;
     this.result = new Promise<WASIExecutionResult>((resolve, reject) => {
       this.reject = reject;
       this.worker = new Worker(new URL("./worker.js", import.meta.url), {});
@@ -49,7 +51,7 @@ export class WASIWorkerHost {
               message.name,
               message.args,
               message.ret,
-              message.data
+              message.data,
             );
             break;
           case "result":
@@ -74,15 +76,23 @@ export class WASIWorkerHost {
         fs: this.context.fs,
         isTTY: this.context.isTTY,
       });
-    }).then((result) => {
-      this.worker?.terminate();
-      return result;
-    });
+    })
+      .then((result) => {
+        this.isRunning = false;
+        this.worker?.terminate();
+        return result;
+      })
+      .catch((err) => {
+        this.isRunning = false;
+        this.worker?.terminate();
+        throw err;
+      });
 
     return this.result;
   }
 
   kill() {
+    this.isRunning = false;
     if (!this.worker) {
       throw new Error("WASIWorker has not started");
     }
@@ -98,6 +108,9 @@ export class WASIWorkerHost {
 
     // first four bytes (Int32) is the length of the text
     while (view.getInt32(0) !== 0) {
+      if (!this.isRunning) {
+        return;
+      }
       // TODO: Switch to Atomics.waitAsync when supported by firefox
       await new Promise((resolve) => setTimeout(resolve, 0));
     }
@@ -117,6 +130,9 @@ export class WASIWorkerHost {
 
     // TODO: Switch to Atomics.waitAsync when supported by firefox
     while (view.getInt32(0) !== 0) {
+      if (!this.isRunning) {
+        return;
+      }
       await new Promise((resolve) => setTimeout(resolve, 0));
     }
 

--- a/packages/sandbox/lib/runtime.ts
+++ b/packages/sandbox/lib/runtime.ts
@@ -18,7 +18,7 @@ export function runCode(
   options: {
     stdin?: string;
     timeout?: number;
-  } = {}
+  } = {},
 ): Promise<RunResult> {
   const fs: WASIFS = {
     "/program": {
@@ -41,9 +41,14 @@ export async function runFS(
   entryPath: string,
   fs: WASIFS,
   options: {
-    stdin?: string;
+    // Accept string (existing behaviour) or stream-like types for streaming stdin.
+    stdin?:
+      | string
+      | AsyncIterable<string>
+      | ReadableStream<string>
+      | (() => AsyncIterable<string>);
     timeout?: number;
-  } = {}
+  } = {},
 ): Promise<RunResult> {
   const commands = commandsForRuntime(runtime, entryPath);
 
@@ -80,13 +85,21 @@ export async function runFS(
   }
 
   try {
-    const resultWithLimits = await _startWASIWithLimits(
-      binaryPath,
-      {
+    // If caller passed a streaming stdin (AsyncIterable / ReadableStream / function),
+    // use WASIWorkerHost directly so we can push chunks as they arrive.
+    let resultWithLimits: { result: WASIExecutionResult } | undefined;
+
+    const isStreamInput =
+      options.stdin != null &&
+      (isAsyncIterable(options.stdin) ||
+        isReadableStream(options.stdin) ||
+        typeof options.stdin === "function");
+
+    if (isStreamInput) {
+      const workerHost = new WASIWorkerHost(binaryPath, {
         args: [run.binaryName, ...(run.args ?? [])],
         env: run.env,
         fs,
-        stdin: options.stdin,
         stdout: (out: string) => {
           prepare.stdout += out;
           prepare.tty += out;
@@ -95,14 +108,79 @@ export async function runFS(
           prepare.stderr += err;
           prepare.tty += err;
         },
-      },
-      {
-        timeout: options.timeout,
-      }
-    );
+      });
 
-    prepare.fs = { ...fs, ...resultWithLimits.result.fs };
-    prepare.exitCode = resultWithLimits.result.exitCode;
+      // Start the worker (returns a Promise that resolves to WASIExecutionResult)
+      const runPromise = workerHost.start();
+
+      // push chunks asynchronously (do not await the entire runPromise here)
+      (async () => {
+        try {
+          // normalize to AsyncIterable<string>
+          let asyncIter: AsyncIterable<string> | undefined;
+
+          if (isAsyncIterable(options.stdin)) {
+            asyncIter = options.stdin as AsyncIterable<string>;
+          } else if (isReadableStream(options.stdin)) {
+            const reader = (
+              options.stdin as ReadableStream<string>
+            ).getReader();
+            async function* fromReader() {
+              try {
+                while (true) {
+                  const { value, done } = await reader.read();
+                  if (done) break;
+                  if (value != null) yield value;
+                }
+              } finally {
+                reader.releaseLock();
+              }
+            }
+            asyncIter = fromReader();
+          } else if (typeof options.stdin === "function") {
+            asyncIter = (options.stdin as () => AsyncIterable<string>)();
+          }
+
+          if (asyncIter) {
+            for await (const chunk of asyncIter) {
+              // Use safe splitter: will split large chunk into multiple UTF-8-safe sub-strings
+              await pushStringSafely(workerHost, chunk);
+            }
+          }
+        } finally {
+          // signal EOF
+          await workerHost.pushEOF();
+        }
+      })();
+
+      // wait for run to finish
+      resultWithLimits = await runPromise.then((r) => ({ result: r }));
+    } else {
+      // old behaviour: string stdin (or undefined) -> use existing helper
+      resultWithLimits = await _startWASIWithLimits(
+        binaryPath,
+        {
+          args: [run.binaryName, ...(run.args ?? [])],
+          env: run.env,
+          fs,
+          stdin: options.stdin as string | undefined,
+          stdout: (out: string) => {
+            prepare.stdout += out;
+            prepare.tty += out;
+          },
+          stderr: (err: string) => {
+            prepare.stderr += err;
+            prepare.tty += err;
+          },
+        },
+        {
+          timeout: options.timeout,
+        },
+      );
+    }
+
+    prepare.fs = { ...fs, ...resultWithLimits!.result.fs };
+    prepare.exitCode = resultWithLimits!.result.exitCode;
 
     return prepare;
   } catch (e) {
@@ -139,7 +217,7 @@ export class PrepareError extends Error {
 export async function headlessPrepareFS(
   prepareCommands: Command[],
   fs: WASIFS,
-  limits: Partial<Limits> = {}
+  limits: Partial<Limits> = {},
 ) {
   const prepare: CompleteResult = {
     resultType: "complete",
@@ -174,7 +252,7 @@ export async function headlessPrepareFS(
           prepare.tty += err;
         },
       },
-      limits
+      limits,
     );
 
     prepare.fs = resultWithLimits.result.fs;
@@ -187,7 +265,7 @@ export async function headlessPrepareFS(
       // If a prepare step fails then we stop.
       throw new PrepareError(
         "Prepare step returned a non-zero exit code",
-        prepare
+        prepare,
       );
     }
   }
@@ -209,12 +287,12 @@ type Context = Omit<WASIContextOptions, "stdin"> & { stdin: string };
 async function _startWASIWithLimits(
   binaryPath: string,
   context: Partial<Context>,
-  limits: Partial<Limits>
+  limits: Partial<Limits>,
 ): Promise<WASIExecutionResultWithLimits> {
   const startTime = performance.now();
   const workerHost = new WASIWorkerHost(
     makeURLFromFilePath(binaryPath),
-    context
+    context,
   );
 
   if (context.stdin) {
@@ -224,7 +302,7 @@ async function _startWASIWithLimits(
   let result: WASIExecutionResult | "timeout";
   if (limits.timeout) {
     const timeoutPromise: Promise<"timeout"> = new Promise((resolve) =>
-      setTimeout(() => resolve("timeout"), limits.timeout! * 1000)
+      setTimeout(() => resolve("timeout"), limits.timeout! * 1000),
     );
 
     result = await Promise.race([workerHost.start(), timeoutPromise]);
@@ -252,5 +330,72 @@ async function _startWASIWithLimits(
 class TimeoutError extends Error {
   constructor() {
     super("Execution timed out");
+  }
+}
+
+/*
+  Helper utilities for streaming stdin support
+*/
+
+// Type guards
+function isAsyncIterable(x: any): x is AsyncIterable<string> {
+  return !!x && typeof x[Symbol.asyncIterator] === "function";
+}
+
+function isReadableStream(x: any): x is ReadableStream<string> {
+  return !!x && typeof (x as any).getReader === "function";
+}
+
+// Split a Uint8Array into chunks <= maxBytes, ensuring we don't cut in the middle
+// of a UTF-8 multi-byte sequence (by avoiding continuation bytes 0x80..0xBF at chunk end).
+function splitUint8ArrayIntoUtf8SafeSlices(
+  bytes: Uint8Array,
+  maxBytes: number,
+): Uint8Array[] {
+  const out: Uint8Array[] = [];
+  let offset = 0;
+  while (offset < bytes.length) {
+    // Proposed end
+    let end = Math.min(offset + maxBytes, bytes.length);
+
+    // If end is at bytes.length we're done; otherwise ensure end is not a UTF-8 continuation byte.
+    if (end < bytes.length) {
+      // Move end left until not a continuation byte (0b10xxxxxx)
+      while (end > offset && (bytes[end] & 0b1100_0000) === 0b1000_0000) {
+        end -= 1;
+      }
+      // Edge case: if we couldn't move (a single codepoint > maxBytes), fall back to forcing split
+      // at maxBytes (this will likely produce replacement chars, but unavoidable unless buffer bigger).
+      if (end === offset) {
+        end = Math.min(offset + maxBytes, bytes.length);
+      }
+    }
+
+    out.push(bytes.slice(offset, end));
+    offset = end;
+  }
+  return out;
+}
+
+// Safely push a JS string to workerHost by splitting it into UTF-8-safe sub-strings
+// that fit into the workerHost.stdinBuffer (availableBytes = buffer.byteLength - 4).
+async function pushStringSafely(host: WASIWorkerHost, str: string) {
+  const encoder = new TextEncoder();
+  const bytes = encoder.encode(str);
+  // compute max payload bytes (subtract 4 bytes used as header)
+  const totalBytes = (host.stdinBuffer as SharedArrayBuffer).byteLength;
+  const maxPayload = Math.max(0, totalBytes - 4);
+  if (bytes.length <= maxPayload) {
+    // small enough, push whole string
+    await host.pushStdin(str);
+    return;
+  }
+
+  // split into safe byte slices, then decode each slice back to string before pushing
+  const slices = splitUint8ArrayIntoUtf8SafeSlices(bytes, maxPayload);
+  const decoder = new TextDecoder();
+  for (const s of slices) {
+    const subStr = decoder.decode(s);
+    await host.pushStdin(subStr);
   }
 }

--- a/packages/sandbox/lib/runtime.ts
+++ b/packages/sandbox/lib/runtime.ts
@@ -10,13 +10,17 @@ import {
 } from "./commands.js";
 import { fetchWASIFS, makeURLFromFilePath, makeRunnoError } from "./helpers.js";
 import { CompleteResult, RunResult, Runtime } from "./types.js";
-import { WASIWorkerHost } from "./host.js";
+import { WASIWorkerHost, WASIWorkerHostKilledError } from "./host.js";
 
 export function runCode(
   runtime: Runtime,
   code: string,
   options: {
-    stdin?: string;
+    stdin?:
+      | string
+      | AsyncIterable<string>
+      | ReadableStream<string>
+      | (() => AsyncIterable<string> | ReadableStream<string>);
     timeout?: number;
   } = {},
 ): Promise<RunResult> {
@@ -46,7 +50,7 @@ export async function runFS(
       | string
       | AsyncIterable<string>
       | ReadableStream<string>
-      | (() => AsyncIterable<string>);
+      | (() => AsyncIterable<string> | ReadableStream<string>);
     timeout?: number;
   } = {},
 ): Promise<RunResult> {
@@ -84,107 +88,113 @@ export async function runFS(
     }
   }
 
-  try {
-    // If caller passed a streaming stdin (AsyncIterable / ReadableStream / function),
-    // use WASIWorkerHost directly so we can push chunks as they arrive.
-    let resultWithLimits: { result: WASIExecutionResult } | undefined;
+  const isStreamInput =
+    options.stdin != null &&
+    (isAsyncIterable(options.stdin) ||
+      isReadableStream(options.stdin) ||
+      typeof options.stdin === "function");
 
-    const isStreamInput =
-      options.stdin != null &&
-      (isAsyncIterable(options.stdin) ||
-        isReadableStream(options.stdin) ||
-        typeof options.stdin === "function");
+  const workerHost = new WASIWorkerHost(binaryPath, {
+    args: [run.binaryName, ...(run.args ?? [])],
+    env: run.env,
+    fs,
+    stdout: (out: string) => {
+      prepare.stdout += out;
+      prepare.tty += out;
+    },
+    stderr: (err: string) => {
+      prepare.stderr += err;
+      prepare.tty += err;
+    },
+  });
 
-    if (isStreamInput) {
-      const workerHost = new WASIWorkerHost(binaryPath, {
-        args: [run.binaryName, ...(run.args ?? [])],
-        env: run.env,
-        fs,
-        stdout: (out: string) => {
-          prepare.stdout += out;
-          prepare.tty += out;
-        },
-        stderr: (err: string) => {
-          prepare.stderr += err;
-          prepare.tty += err;
-        },
-      });
+  // Start the worker
+  const runPromise = workerHost.start();
 
-      // Start the worker (returns a Promise that resolves to WASIExecutionResult)
-      const runPromise = workerHost.start();
+  // push chunks asynchronously
+  const stdinPromise = (async () => {
+    try {
+      if (isStreamInput) {
+        // normalize to AsyncIterable<string>
+        let asyncIter: AsyncIterable<string> | undefined;
 
-      // push chunks asynchronously (do not await the entire runPromise here)
-      (async () => {
-        try {
-          // normalize to AsyncIterable<string>
-          let asyncIter: AsyncIterable<string> | undefined;
-
-          if (isAsyncIterable(options.stdin)) {
-            asyncIter = options.stdin as AsyncIterable<string>;
-          } else if (isReadableStream(options.stdin)) {
-            const reader = (
-              options.stdin as ReadableStream<string>
-            ).getReader();
-            async function* fromReader() {
-              try {
-                while (true) {
-                  const { value, done } = await reader.read();
-                  if (done) break;
-                  if (value != null) yield value;
-                }
-              } finally {
-                reader.releaseLock();
-              }
-            }
-            asyncIter = fromReader();
-          } else if (typeof options.stdin === "function") {
-            asyncIter = (options.stdin as () => AsyncIterable<string>)();
+        if (isAsyncIterable(options.stdin)) {
+          asyncIter = options.stdin as AsyncIterable<string>;
+        } else if (isReadableStream(options.stdin)) {
+          asyncIter = readableStreamToAsyncIterable(
+            options.stdin as ReadableStream<string>,
+          );
+        } else if (typeof options.stdin === "function") {
+          const result = (
+            options.stdin as () =>
+              | AsyncIterable<string>
+              | ReadableStream<string>
+          )();
+          if (isAsyncIterable(result)) {
+            asyncIter = result;
+          } else if (isReadableStream(result)) {
+            asyncIter = readableStreamToAsyncIterable(result);
           }
-
-          if (asyncIter) {
-            for await (const chunk of asyncIter) {
-              // Use safe splitter: will split large chunk into multiple UTF-8-safe sub-strings
-              await pushStringSafely(workerHost, chunk);
-            }
-          }
-        } finally {
-          // signal EOF
-          await workerHost.pushEOF();
         }
-      })();
+        if (asyncIter) {
+          for await (const chunk of asyncIter) {
+            if (!workerHost.isRunning) break;
+            await pushStringSafely(workerHost, chunk);
+          }
+        }
+      } else if (typeof options.stdin === "string") {
+        await pushStringSafely(workerHost, options.stdin);
+      }
+    } finally {
+      // signal EOF
+      await workerHost.pushEOF();
+    }
+  })();
 
-      // wait for run to finish
-      resultWithLimits = await runPromise.then((r) => ({ result: r }));
-    } else {
-      // old behaviour: string stdin (or undefined) -> use existing helper
-      resultWithLimits = await _startWASIWithLimits(
-        binaryPath,
-        {
-          args: [run.binaryName, ...(run.args ?? [])],
-          env: run.env,
-          fs,
-          stdin: options.stdin as string | undefined,
-          stdout: (out: string) => {
-            prepare.stdout += out;
-            prepare.tty += out;
-          },
-          stderr: (err: string) => {
-            prepare.stderr += err;
-            prepare.tty += err;
-          },
-        },
-        {
-          timeout: options.timeout,
-        },
+  // Prevent unhandled rejections if stdinPromise fails before we await it.
+  stdinPromise.catch(() => {});
+
+  try {
+    // Wrap stdinPromise to only reject on error, and not resolve the race on success
+    const stdinErrorPromise = stdinPromise.then(
+      () => new Promise<never>(() => {}),
+    );
+
+    let result: WASIExecutionResult | "timeout";
+    if (options.timeout) {
+      const timeoutPromise: Promise<"timeout"> = new Promise((resolve) =>
+        setTimeout(() => resolve("timeout"), options.timeout! * 1000),
       );
+      result = await Promise.race([
+        runPromise,
+        timeoutPromise,
+        stdinErrorPromise,
+      ]);
+    } else {
+      result = await Promise.race([runPromise, stdinErrorPromise]);
     }
 
-    prepare.fs = { ...fs, ...resultWithLimits!.result.fs };
-    prepare.exitCode = resultWithLimits!.result.exitCode;
+    if (result === "timeout") {
+      workerHost.kill();
+      await stdinPromise.catch(() => {}); // cleanup
+      return {
+        resultType: "timeout",
+      };
+    }
+
+    // Ensure we also wait for any errors in the stdin background task
+    await stdinPromise;
+
+    prepare.fs = { ...fs, ...result.fs };
+    prepare.exitCode = result.exitCode;
 
     return prepare;
   } catch (e) {
-    if (e instanceof TimeoutError) {
+    if (
+      e instanceof TimeoutError ||
+      e instanceof WASIWorkerHostKilledError ||
+      (e && (e as any).constructor?.name === "WASIWorkerHostKilledError")
+    ) {
       return {
         resultType: "timeout",
       };
@@ -346,6 +356,21 @@ function isReadableStream(x: any): x is ReadableStream<string> {
   return !!x && typeof (x as any).getReader === "function";
 }
 
+async function* readableStreamToAsyncIterable(
+  stream: ReadableStream<string>,
+): AsyncIterable<string> {
+  const reader = stream.getReader();
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      if (value != null) yield value;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
 // Split a Uint8Array into chunks <= maxBytes, ensuring we don't cut in the middle
 // of a UTF-8 multi-byte sequence (by avoiding continuation bytes 0x80..0xBF at chunk end).
 function splitUint8ArrayIntoUtf8SafeSlices(
@@ -380,6 +405,9 @@ function splitUint8ArrayIntoUtf8SafeSlices(
 // Safely push a JS string to workerHost by splitting it into UTF-8-safe sub-strings
 // that fit into the workerHost.stdinBuffer (availableBytes = buffer.byteLength - 4).
 async function pushStringSafely(host: WASIWorkerHost, str: string) {
+  if (!str) {
+    return;
+  }
   const encoder = new TextEncoder();
   const bytes = encoder.encode(str);
   // compute max payload bytes (subtract 4 bytes used as header)

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -36,10 +36,10 @@
     "url": "git+https://github.com/taybenlor/runno.git"
   },
   "scripts": {
-    "bootstrap": "cp -R ../../langs/ ./public/langs/",
+    "bootstrap": "cp -R ../../langs ./public/",
     "test": "vitest run",
     "test:watch": "vitest",
-    "build": "tsup && cp -R ./public/langs/ ./dist/langs/"
+    "build": "tsup && cp -R ./public/langs ./dist/"
   },
   "bugs": {
     "url": "https://github.com/taybenlor/runno/issues"


### PR DESCRIPTION
This PR adds support for streaming stdin (AsyncIterable, ReadableStream, and factory functions) to runFS and runCode.

Key improvements:
- Unified stdin handling logic
- Timeout and error propagation for streams
- UTF-8 safe chunking to prevent corruption at boundaries
- Backpressure support via SharedArrayBuffer synchronization
- Comprehensive tests for edge cases and stress scenarios

Closes #362