### PR TITLE
Design doc: WASIX support for @runno/wasi

### DIFF
--- a/packages/wasi/WASIX-PLAN.md
+++ b/packages/wasi/WASIX-PLAN.md
@@ -322,12 +322,58 @@ host configuration among many.
 
 A small set of tests depends on resuming WASM execution at a specific frame
 from the outside — principally `proc_fork`, asynchronous signal pre-emption,
-and cross-frame `setjmp`/`longjmp`. See the non-goals section above for why
-these aren't achievable with a provider alone. The test harness carries an
-explicit skip list with a one-line justification per entry. Any test that
-*can* be made to pass with sufficiently capable providers — including
-`proc_exec`, `proc_spawn`, threads, futex, sockets, and TTY — is not in
-this list.
+and cross-frame `setjmp`/`longjmp`. See [the reasoning below](#why-those-tests-cant-be-passed-by-providers-alone)
+for why these aren't achievable with a provider alone. The test harness
+carries an explicit skip list with a one-line justification per entry. Any
+test that *can* be made to pass with sufficiently capable providers —
+including `proc_exec`, `proc_spawn`, threads, futex, sockets, and TTY — is
+not in this list.
+
+### Why those tests can't be passed by providers alone
+
+Take `proc_fork` as the canonical case. The syscall requires:
+
+1. The **parent** resumes after the fork() import call with `pid = <child>`.
+2. A **child** — a separate WASM instance — resumes after the same fork() call
+   with `pid = 0`, with a clone of the parent's memory, and with every local
+   variable in every active frame preserved.
+
+(1) is free — it's a normal import return. (2) is the blocker.
+
+When a provider is handling an import, the guest is paused inside that call.
+Via `WebAssembly.Instance` the provider can see:
+
+- `memory.buffer` — readable, cloneable.
+- Exports (globals, tables, functions) — readable, callable from the beginning.
+
+It cannot see the guest's **call stack** or **program counter**. WebAssembly
+does not expose these to JS. Engines implement the stack differently —
+V8 uses the native C stack, Wasmtime its own, SpiderMonkey different again —
+and the spec deliberately leaves it opaque so engines can optimise freely.
+There is no API for it, public or private.
+
+Entering a WASM instance from JS means calling an export from its start.
+There is no "resume at frame N, instruction M." So a provider can clone
+memory but cannot tell the child instance *where to begin*.
+
+The same limitation hits two related syscalls:
+
+- **Async signal delivery.** "Pause the running guest, jump to the registered
+  handler, then resume where we were" has the same resume-at-frame need.
+  Self-raised signals that happen at controlled yield points are fine;
+  signals delivered from outside the guest's current call are not.
+- **Cross-frame `setjmp`/`longjmp`.** Unwinding from inside a JS-imported
+  call back to a target several WASM frames up requires popping the guest
+  stack from outside. Same blocker.
+
+In all three, the root cause is identical: **WASM execution state is not
+reifiable from JS**.
+
+Both workarounds described in [Future: pause/resume support](#future-pauseresume-support)
+operate below the provider layer. Asyncify moves the stack *into* guest
+memory where JS can see it; JSPI adds a first-class pause/resume primitive
+at the engine. Neither is something a provider can do at call time — which
+is why v1 ships with these tests skipped rather than working around them.
 
 ### Future: pause/resume support
 

--- a/packages/wasi/WASIX-PLAN.md
+++ b/packages/wasi/WASIX-PLAN.md
@@ -57,18 +57,26 @@ New root exports from `@runno/wasi`:
 // Core
 export { WASIX, WASIXContext, WASIXWorkerHost } from "./wasix/...";
 
-// Raw provider interfaces — host implements these for deep control
+// Raw provider interfaces — always synchronous, consumed by `WASIX`
 export type {
   ClockProvider, RandomProvider,
   TTYProvider, ThreadsProvider, FutexProvider,
   SignalsProvider, SocketsProvider, ProcProvider,
 } from "./wasix/providers.js";
 
+// Async-capable variants — accepted only by WASIXWorkerHost
+export type {
+  AsyncClockProvider, AsyncRandomProvider,
+  AsyncTTYProvider, AsyncThreadsProvider, AsyncFutexProvider,
+  AsyncSignalsProvider, AsyncSocketsProvider, AsyncProcProvider,
+  AsyncCapable,
+} from "./wasix/providers/async.js";
+
 // Ergonomic providers — concrete classes hosts can drop in
 export {
-  HTTPProvider,        // implements SocketsProvider
-  FileSystemProvider,  // wraps WASIDrive, replaceable
-  ConsoleTTYProvider,  // implements TTYProvider
+  HTTPProvider,        // AsyncSocketsProvider (Fetch-style) — worker-only
+  FileSystemProvider,  // wraps WASIDrive; sync + async variants
+  ConsoleTTYProvider,  // TTYProvider (sync)
 } from "./wasix/providers/ergonomic.js";
 ```
 
@@ -139,13 +147,14 @@ type WASIXContextOptions = {
   fs: WASIFS;
   args: string[];
   env: Record<string, string>;
-  stdin: (maxByteLength: number) => string | null | Promise<string | null>;
-  stdout: (out: string) => void | Promise<void>;
-  stderr: (err: string) => void | Promise<void>;
+  stdin: (maxByteLength: number) => string | null;
+  stdout: (out: string) => void;
+  stderr: (err: string) => void;
   isTTY: boolean;
   debug?: DebugFn;
 
-  // Providers — all optional, all async-capable
+  // Providers — all sync. Async variants are configured via
+  // WASIXWorkerHostOptions; see "Async-capable providers" below.
   clock?:   ClockProvider;    // clock_time_get, clock_res_get
   random?:  RandomProvider;   // random_get
   tty?:     TTYProvider;      // tty_get, tty_set
@@ -161,76 +170,72 @@ Every method uses JS-native shapes — `Uint8Array`, `bigint`, plain objects
 for structured types like `SockAddr`. **Raw pointers never leave the
 `WASIX` class.**
 
+**Every provider method is synchronous.** The WASM guest calls imports
+synchronously and the `WASIX` class never awaits, so the provider API has
+no Promise shape at all. A method returns a value or throws — nothing
+else. This applies to raw interfaces and to the ergonomic providers built
+on top of them.
+
 These are **raw interfaces** — close to the WASIX ABI (fds, `sockaddr`,
 signo). A host can implement any raw interface directly if it wants deep
 control over that slot. For most hosts Runno ships **ergonomic providers**
 (see below) that wrap the raw interfaces in web-native shapes. Both levels
 coexist — ergonomic is the one-liner, raw is the escape hatch.
 
-Provider methods may return `T` or `Promise<T>` at the type level, but the
-runtime rule depends on how the `WASIX` instance is driven:
-
-- **Main thread (`WASIX.start(...)`):** sync providers only. The WASM guest
-  calls imports synchronously; the main thread owns the event loop where
-  any Promise would settle, so it can't block mid-syscall. An async
-  provider configured on the main thread is a config-time error. This
-  matches existing `WASI` behaviour — today's `WASI` main-thread path is
-  fully synchronous.
-- **Worker (`WASIXWorkerHost`):** both sync and async providers work.
-  Async providers go through the syscall bridge (see
-  [Async syscall bridge](#async-syscall-bridge)).
+Async resources — HTTP requests, IndexedDB, anything that yields to the
+event loop — are handled at the `WASIXWorkerHost` layer, which takes
+**async-capable** provider variants (see
+[Async-capable providers](#async-capable-providers-worker-only) below) and
+converts them back into sync providers via the syscall bridge. The inner
+`WASIX` class only ever sees sync providers.
 
 Raw interface shapes (final forms pinned during implementation):
 
 ```ts
 interface ClockProvider {
-  now(id: ClockId): bigint | Promise<bigint>;        // nanoseconds
-  resolution(id: ClockId): bigint | Promise<bigint>;
+  now(id: ClockId): bigint;                  // nanoseconds
+  resolution(id: ClockId): bigint;
 }
 
 interface RandomProvider {
-  fill(buf: Uint8Array): void | Promise<void>;
+  fill(buf: Uint8Array): void;
 }
 
 interface ThreadsProvider {
-  spawn(startArg: number): number | Promise<number>;    // tid
-  join(tid: number): number | Promise<number>;          // exit code
+  spawn(startArg: number): number;    // tid
+  join(tid: number): number;          // exit code
   exit(code: number): void;
-  sleep(durationNs: bigint): void | Promise<void>;
+  sleep(durationNs: bigint): void;
   id(): number;
   parallelism(): number;
-  signal(tid: number, signo: number): Result | Promise<Result>;
+  signal(tid: number, signo: number): Result;
 }
 
 interface FutexProvider {
-  wait(addr: number, expected: number, timeoutNs: bigint | null)
-    : number | Promise<number>;
-  wake(addr: number, count: number): number | Promise<number>;
+  wait(addr: number, expected: number, timeoutNs: bigint | null): number;
+  wake(addr: number, count: number): number;
 }
 
 interface SocketsProvider {
-  open(af: number, type: number, proto: number): number | Promise<number>;
-  bind(fd: number, addr: SockAddr): Result | Promise<Result>;
-  connect(fd: number, addr: SockAddr): Result | Promise<Result>;
-  listen(fd: number, backlog: number): Result | Promise<Result>;
-  accept(fd: number): number | Promise<number>;
-  send(fd: number, bufs: Uint8Array[], flags: number)
-    : number | Promise<number>;
-  recv(fd: number, bufs: Uint8Array[], flags: number)
-    : SockRecvResult | Promise<SockRecvResult>;
-  shutdown(fd: number, how: number): Result | Promise<Result>;
-  addrResolve(host: string, port: number, hints: AddrHints)
-    : SockAddr[] | Promise<SockAddr[]>;
+  open(af: number, type: number, proto: number): number;
+  bind(fd: number, addr: SockAddr): Result;
+  connect(fd: number, addr: SockAddr): Result;
+  listen(fd: number, backlog: number): Result;
+  accept(fd: number): number;
+  send(fd: number, bufs: Uint8Array[], flags: number): number;
+  recv(fd: number, bufs: Uint8Array[], flags: number): SockRecvResult;
+  shutdown(fd: number, how: number): Result;
+  addrResolve(host: string, port: number, hints: AddrHints): SockAddr[];
   // …getsockopt/setsockopt, addr_local/peer, status
 }
 
 interface ProcProvider {
   id(): number;
   parentId(): number;
-  fork(): ProcForkResult | Promise<ProcForkResult>;
-  spawn(req: ProcSpawnRequest): number | Promise<number>;
-  exec(req: ProcExecRequest): Result | Promise<Result>;
-  join(pid: number): ProcExitInfo | Promise<ProcExitInfo>;
+  fork(): ProcForkResult;
+  spawn(req: ProcSpawnRequest): number;
+  exec(req: ProcExecRequest): Result;
+  join(pid: number): ProcExitInfo;
 }
 
 // fork / spawn / exec receive plain-data requests — opaque JS objects
@@ -239,15 +244,47 @@ interface ProcProvider {
 // directly; it decides on its own what "starting a new process" means.
 
 interface SignalsProvider {
-  register(signo: number, handler: number): Result | Promise<Result>;
-  raiseInterval(signo: number, intervalNs: bigint): Result | Promise<Result>;
+  register(signo: number, handler: number): Result;
+  raiseInterval(signo: number, intervalNs: bigint): Result;
 }
 
 interface TTYProvider {
-  get(): TTYState | Promise<TTYState>;       // cols, rows, pixel size, echo, line, raw, …
-  set(state: TTYState): Result | Promise<Result>;
+  get(): TTYState;       // cols, rows, pixel size, echo, line, raw, …
+  set(state: TTYState): Result;
 }
 ```
+
+### Async-capable providers (worker-only)
+
+A single utility type lifts any raw provider into an async-capable variant
+by making every method optionally return a Promise:
+
+```ts
+type AsyncCapable<T> = {
+  [K in keyof T]: T[K] extends (...args: infer A) => infer R
+    ? (...args: A) => R | Promise<R>
+    : T[K];
+};
+
+type AsyncClockProvider   = AsyncCapable<ClockProvider>;
+type AsyncSocketsProvider = AsyncCapable<SocketsProvider>;
+// …one per raw provider
+```
+
+`WASIXWorkerHost` accepts these variants in its options (stdio callbacks
+likewise). At runtime it runs the inner `WASIX` in a dedicated worker;
+when a syscall fires, the bridge (see
+[Async syscall bridge](#async-syscall-bridge)) hops to the main thread,
+invokes the host's async-capable provider, awaits the Promise if one comes
+back, and returns the resolved value to the worker. The worker unblocks on
+`Atomics.wait` and passes the value into the sync inner `WASIX` as a
+normal return.
+
+From the guest and from `WASIX`, there is no async. From the host's
+perspective, any provider method may return a Promise.
+
+The main-thread `WASIX(...)` entry point takes sync providers only —
+async-capable variants are a type error there.
 
 ### Ergonomic providers (bundled)
 
@@ -257,8 +294,8 @@ in terms of web-native primitives. Opt-in — the host picks which level of
 engagement they want per concern. Deep control over sockets while using the
 bundled clock and filesystem is a normal configuration.
 
-- **`HTTPProvider` (implements `SocketsProvider`).** Most hosts care about
-  HTTP, not raw TCP/UDP. `HTTPProvider` exposes two handlers:
+- **`HTTPProvider` (implements `AsyncSocketsProvider`).** Most hosts care
+  about HTTP, not raw TCP/UDP. `HTTPProvider` exposes two handlers:
   ```ts
   new HTTPProvider({
     outgoing: (req: Request) => Response | Promise<Response>,   // guest-initiated
@@ -267,14 +304,16 @@ bundled clock and filesystem is a normal configuration.
   ```
   Internally it translates socket-level calls (`connect`, `send`, `recv`)
   into Fetch-style request/response pairs and parses HTTP on the wire.
-  Hosts that need raw TCP still implement `SocketsProvider` directly.
+  Because the handlers return Promises, `HTTPProvider` is
+  **async-capable** and usable only on `WASIXWorkerHost`. Hosts that need
+  raw TCP implement `SocketsProvider` (or its async variant) directly.
 - **`FileSystemProvider`.** Promotes the existing `WASIDrive` from an
-  internal implementation detail to a public provider. Hosts can swap it
-  wholesale — e.g. to back files with IndexedDB or a server sync protocol —
-  without touching `fd_*` syscalls. Default: today's in-memory drive.
+  internal implementation detail to a public provider. Sync by default
+  (today's in-memory drive); an `AsyncFileSystemProvider` variant ships for
+  hosts backing files with IndexedDB or a server sync protocol (worker-only).
 - **`ConsoleTTYProvider` (implements `TTYProvider`).** Reflects the
   existing `isTTY` / `stdin` / `stdout` / `stderr` surface — what preview1
-  hosts configure today, lifted into the provider model.
+  hosts configure today, lifted into the provider model. Sync.
 
 Some raw interfaces are already at the right level and don't get an
 ergonomic wrapper: `ClockProvider`, `RandomProvider`, `ThreadsProvider`,
@@ -284,12 +323,10 @@ directly. Runno still ships bundled simulations for each (see
 
 ## Async syscall bridge
 
-Async providers are only supported inside a `WASIXWorker`. The WASM guest
-is synchronous from its own point of view — imports return a value, not a
-Promise — so when a provider returns a Promise mid-syscall, the worker
-thread has to block until it resolves. The main thread can't block (it owns
-the event loop where the Promise would settle), which is why async is
-worker-only and the main thread is restricted to sync providers.
+The bridge is how `WASIXWorkerHost` turns a host's async-capable provider
+into the sync provider the inner `WASIX` class consumes. It's an
+implementation detail of the worker host — neither `WASIX` nor provider
+authors see it; the inner guest runs against pure sync providers.
 
 Mechanism — a generalised version of the existing `stdin` pattern:
 
@@ -311,12 +348,13 @@ single-threaded within its worker. When multiple TIDs run in separate workers
 This replaces the bespoke `stdin` `SharedArrayBuffer` with a generic
 syscall-bridge protocol; `stdin` becomes one opcode among many.
 
-On the main thread there is no bridge. `WASIX.start(...)` is still async —
-it awaits module fetch and instantiation — but once the guest is running,
-every provider call is invoked synchronously. An async provider wired into
-a main-thread `WASIX` fails at config time. Host picks the mode up front:
-`await WASIX.start(...)` for sync-only runs, `new WASIXWorkerHost(...)` for
-runs that need async providers.
+On the main thread there is no bridge. `WASIX.start(...)` is still async
+— it awaits module fetch and instantiation — but once the guest is
+running, every provider call is invoked synchronously. Host picks the mode
+up front: `await WASIX.start(...)` for runs where every provider is sync,
+or `new WASIXWorkerHost(...)` for runs where any provider may return a
+Promise. The types enforce the split — an async-capable provider passed to
+`WASIX(...)` is a type error.
 
 ## Thread / memory model
 

--- a/packages/wasi/WASIX-PLAN.md
+++ b/packages/wasi/WASIX-PLAN.md
@@ -22,15 +22,24 @@ All of that is a host-side decision; the runtime is unaware.
   (they import both).
 - Clock and Random become overridable providers (enables deterministic
   execution).
+- **Pass the upstream WASIX integration test suite
+  ([`wasmerio/wasix-integration-tests`](https://github.com/wasmerio/wasix-integration-tests))**
+  under a reference provider configuration shipped with the package. See
+  [Validation](#validation).
 
 Every WASIX syscall has a provider slot. Unwired slots return `ENOSYS`.
 
 **Non-goals.**
 
-- Parity with Wasmer's WASIX runtime semantics. Runno is a sandbox; behaviour
-  is whatever the host models.
-- Real socket / fork / exec implementations inside the runtime. Those are
-  host concerns.
+- Tests requiring whole-module state snapshot semantics (`proc_fork`,
+  `proc_exec` that continue execution with a mutated memory image). Wasmer's
+  implementation uses its journaling/snapshot machinery for these; Runno's
+  provider model gives the host an opaque snapshot handle but does not itself
+  implement snapshot-and-resume. Specific tests dependent on that are tracked
+  as known-skipped.
+- Real socket / fork / exec implementations baked into the runtime. Those live
+  in providers — some of which Runno ships (enough to pass the suite), some of
+  which are the host's.
 - `wasix_64v1` (Memory64 / wasm64). No existing toolchain output drives demand;
   the `wasix-libc` chain targets wasm32 in practice. Deferred — the handler
   code would mostly overlap with `wasix_32v1`, so picking it up later is cheap.
@@ -262,6 +271,65 @@ const wasix = new WASIX({
 No provider supplied → runtime falls back to `Date.now()` and
 `crypto.getRandomValues()` — identical to today's `WASI` defaults.
 
+## Validation
+
+Correctness bar: [`wasmerio/wasix-integration-tests`](https://github.com/wasmerio/wasix-integration-tests),
+the upstream WASIX integration suite.
+
+This shapes the design in two concrete ways.
+
+### Reference providers ship with the package
+
+To run the suite end-to-end, a consuming host needs working threads, futex,
+sockets, TTY, signals, clock, and random semantics. The runtime alone cannot
+supply those (it's the sandbox — it never does real work). So the package
+ships two provider tiers:
+
+```
+lib/wasix/providers/
+├── reference/      real-world semantics, enough to pass the upstream suite
+│   ├── worker-threads.ts        real Worker-backed ThreadsProvider
+│   ├── atomics-futex.ts         Atomics.wait/notify on shared memory
+│   ├── node-sockets.ts          node:net / node:dgram SocketsProvider (node only)
+│   ├── ws-proxy-sockets.ts      WebSocket-proxy SocketsProvider (browser)
+│   ├── system-clock.ts          Date.now() / performance.now()
+│   ├── web-crypto-random.ts     crypto.getRandomValues()
+│   ├── passthrough-tty.ts       reflects WASIXContext.isTTY + reasonable winsize
+│   └── self-signal.ts           signal_register + in-process dispatch
+└── deterministic/  test-friendly providers
+    ├── fixed-clock.ts
+    ├── seeded-random.ts
+    ├── mock-sockets.ts
+    ├── mock-threads.ts
+    └── …
+```
+
+Both tiers are exported publicly but importing is opt-in — nothing is wired
+into `WASIXContext` by default. The integration suite runner configures a
+`WASIX` instance with the `reference/` providers; a unit test can use
+`deterministic/` providers or its own fakes.
+
+This keeps the "Runno emulates, you simulate" design intact: the runtime has
+no semantics; the *reference providers* do, and they're just one possible
+host configuration among many.
+
+### Known-skipped tests
+
+A small set of tests depends on WASIX semantics that Runno's provider model
+cannot meaningfully simulate without implementing Wasmer-style journaling in
+the runtime itself — principally those exercising `proc_fork` / `proc_exec`
+that then assert on continued execution with a mutated memory image. These
+will be enumerated in a skip list in the test harness, with a one-line
+justification each. Any test that *can* be made to pass with sufficiently
+capable providers is not in this list.
+
+### CI
+
+The integration suite runs in CI against both provider configurations:
+- Node — `reference/` + `node-sockets`.
+- Browser (Playwright, COOP/COEP) — `reference/` + `ws-proxy-sockets` backed
+  by a local proxy started for the test run.
+
 ## Error model
 
 - Provider slot empty for a given syscall → return `Result.ENOSYS` without
@@ -288,3 +356,5 @@ No provider supplied → runtime falls back to `Date.now()` and
 - Do we expose the syscall-bridge opcodes publicly, so third parties can
   implement providers out-of-process (e.g. over a websocket to a remote host)?
   Attractive for future work; leave closed initially.
+- Exact skip list from `wasix-integration-tests`. Enumerate once PR 1 boots
+  the suite end-to-end; revisit per test rather than guessing ahead.

--- a/packages/wasi/WASIX-PLAN.md
+++ b/packages/wasi/WASIX-PLAN.md
@@ -54,12 +54,22 @@ Every WASIX syscall has a provider slot. Unwired slots return `ENOSYS`.
 New root exports from `@runno/wasi`:
 
 ```ts
+// Core
 export { WASIX, WASIXContext, WASIXWorkerHost } from "./wasix/...";
+
+// Raw provider interfaces — host implements these for deep control
 export type {
   ClockProvider, RandomProvider,
   TTYProvider, ThreadsProvider, FutexProvider,
   SignalsProvider, SocketsProvider, ProcProvider,
 } from "./wasix/providers.js";
+
+// Ergonomic providers — concrete classes hosts can drop in
+export {
+  HTTPProvider,        // implements SocketsProvider
+  FileSystemProvider,  // wraps WASIDrive, replaceable
+  ConsoleTTYProvider,  // implements TTYProvider
+} from "./wasix/providers/ergonomic.js";
 ```
 
 Existing `WASI`, `WASIContext`, `WASIWorkerHost`, and the
@@ -147,11 +157,30 @@ type WASIXContextOptions = {
 };
 ```
 
-All provider methods may be sync or async. Every method uses JS-native shapes
-— `Uint8Array`, `bigint`, `Promise<T>`, plain objects for structured types
-like `SockAddr`. **Raw pointers never leave the `WASIX` class.**
+Every method uses JS-native shapes — `Uint8Array`, `bigint`, plain objects
+for structured types like `SockAddr`. **Raw pointers never leave the
+`WASIX` class.**
 
-Example interface shapes (final forms pinned during implementation):
+These are **raw interfaces** — close to the WASIX ABI (fds, `sockaddr`,
+signo). A host can implement any raw interface directly if it wants deep
+control over that slot. For most hosts Runno ships **ergonomic providers**
+(see below) that wrap the raw interfaces in web-native shapes. Both levels
+coexist — ergonomic is the one-liner, raw is the escape hatch.
+
+Provider methods may return `T` or `Promise<T>` at the type level, but the
+runtime rule depends on how the `WASIX` instance is driven:
+
+- **Main thread (`WASIX.start(...)`):** sync providers only. The WASM guest
+  calls imports synchronously; the main thread owns the event loop where
+  any Promise would settle, so it can't block mid-syscall. An async
+  provider configured on the main thread is a config-time error. This
+  matches existing `WASI` behaviour — today's `WASI` main-thread path is
+  fully synchronous.
+- **Worker (`WASIXWorkerHost`):** both sync and async providers work.
+  Async providers go through the syscall bridge (see
+  [Async syscall bridge](#async-syscall-bridge)).
+
+Raw interface shapes (final forms pinned during implementation):
 
 ```ts
 interface ClockProvider {
@@ -220,12 +249,47 @@ interface TTYProvider {
 }
 ```
 
+### Ergonomic providers (bundled)
+
+Raw interfaces are close to the WASIX ABI, which is right for control but
+verbose. Runno ships ergonomic providers that implement the raw interfaces
+in terms of web-native primitives. Opt-in — the host picks which level of
+engagement they want per concern. Deep control over sockets while using the
+bundled clock and filesystem is a normal configuration.
+
+- **`HTTPProvider` (implements `SocketsProvider`).** Most hosts care about
+  HTTP, not raw TCP/UDP. `HTTPProvider` exposes two handlers:
+  ```ts
+  new HTTPProvider({
+    outgoing: (req: Request) => Response | Promise<Response>,   // guest-initiated
+    incoming: (port: number) => ReadableStream<Request>,         // guest-bound service
+  });
+  ```
+  Internally it translates socket-level calls (`connect`, `send`, `recv`)
+  into Fetch-style request/response pairs and parses HTTP on the wire.
+  Hosts that need raw TCP still implement `SocketsProvider` directly.
+- **`FileSystemProvider`.** Promotes the existing `WASIDrive` from an
+  internal implementation detail to a public provider. Hosts can swap it
+  wholesale — e.g. to back files with IndexedDB or a server sync protocol —
+  without touching `fd_*` syscalls. Default: today's in-memory drive.
+- **`ConsoleTTYProvider` (implements `TTYProvider`).** Reflects the
+  existing `isTTY` / `stdin` / `stdout` / `stderr` surface — what preview1
+  hosts configure today, lifted into the provider model.
+
+Some raw interfaces are already at the right level and don't get an
+ergonomic wrapper: `ClockProvider`, `RandomProvider`, `ThreadsProvider`,
+`FutexProvider`, `SignalsProvider`, `ProcProvider`. Hosts implement them
+directly. Runno still ships bundled simulations for each (see
+[Validation](#validation)).
+
 ## Async syscall bridge
 
-All provider calls can return a Promise. On the main thread this is trivial —
-the `WASIX` class awaits before returning to the guest. Inside a
-`WASIXWorker`, the WASM guest is synchronous from its own point of view and
-needs a way to block until the host-side promise resolves.
+Async providers are only supported inside a `WASIXWorker`. The WASM guest
+is synchronous from its own point of view — imports return a value, not a
+Promise — so when a provider returns a Promise mid-syscall, the worker
+thread has to block until it resolves. The main thread can't block (it owns
+the event loop where the Promise would settle), which is why async is
+worker-only and the main thread is restricted to sync providers.
 
 Mechanism — a generalised version of the existing `stdin` pattern:
 
@@ -247,9 +311,12 @@ single-threaded within its worker. When multiple TIDs run in separate workers
 This replaces the bespoke `stdin` `SharedArrayBuffer` with a generic
 syscall-bridge protocol; `stdin` becomes one opcode among many.
 
-On the main thread (no worker), there is no bridge: `WASIX.start` is an async
-function that awaits provider Promises directly. The public API makes this
-explicit — `await WASIX.start(...)` vs `new WASIXWorkerHost(...)`.
+On the main thread there is no bridge. `WASIX.start(...)` is still async —
+it awaits module fetch and instantiation — but once the guest is running,
+every provider call is invoked synchronously. An async provider wired into
+a main-thread `WASIX` fails at config time. Host picks the mode up front:
+`await WASIX.start(...)` for sync-only runs, `new WASIXWorkerHost(...)` for
+runs that need async providers.
 
 ## Thread / memory model
 

--- a/packages/wasi/WASIX-PLAN.md
+++ b/packages/wasi/WASIX-PLAN.md
@@ -79,8 +79,8 @@ for future `WASIPreview2` / `WASIPreview3` classes alongside.
       │                                  │
 ┌───────────────┐                  ┌───────────────┐
 │  WASI         │                  │  WASIX        │
-│  (preview1 +  │  <── delegates ──│  (wasix_32v1 +│
-│   unstable)   │     preview1/    │   wasix_64v1) │
+│  (preview1 +  │  <── delegates ──│  (wasix_32v1) │
+│   unstable)   │     preview1/    │               │
 │               │     unstable     │               │
 └───────────────┘                  └───────────────┘
 ```
@@ -423,5 +423,5 @@ The integration suite runs in CI against both provider configurations:
 - Do we expose the syscall-bridge opcodes publicly, so third parties can
   implement providers out-of-process (e.g. over a websocket to a remote host)?
   Attractive for future work; leave closed initially.
-- Exact skip list from `wasix-integration-tests`. Enumerate once PR 1 boots
-  the suite end-to-end; revisit per test rather than guessing ahead.
+- Exact skip list from `wasix-integration-tests`. Enumerate once the runtime
+  boots the suite end-to-end; revisit per test rather than guessing ahead.

--- a/packages/wasi/WASIX-PLAN.md
+++ b/packages/wasi/WASIX-PLAN.md
@@ -1,79 +1,133 @@
-# WASIX support — plan
+# WASIX support — technical design
 
-*Status: in progress. Living document — revise as decisions land.*
+*Status: design phase. Describes the target architecture; revise as decisions land.*
 
 ## Goal
 
-Support WASIX binaries in `@runno/wasi` using Runno's existing sandboxing
-philosophy: the runtime provides the marshalling between WASM memory and
-JavaScript; the host supplies the semantics via pluggable providers.
+Extend `@runno/wasi` to run WASIX binaries while preserving Runno's existing
+sandbox philosophy: the runtime provides marshalling between WASM memory and
+JavaScript; the host supplies every semantic via a pluggable provider.
+The runtime never performs a real syscall.
 
 > Runno emulates. You simulate.
 
-The runtime never performs a real syscall. For every WASIX capability, the host
-decides what "the world" looks like — a real `Worker`, a scripted scheduler, a
-recorded trace, a network simulator, `/dev/null`. Runno doesn't care.
+A host can model threads as a cooperative scheduler, a network as a recorded
+trace, `proc_fork` as a canned child handle, or any syscall as `/dev/null`.
+All of that is a host-side decision; the runtime is unaware.
 
-## Decisions
+## Scope
 
-- **Separate root export `WASIX`.** The existing `WASI` class and its
-  preview1/unstable behaviour are untouched. `WASIX` is a new class with its own
-  context, worker host, and import namespaces. This leaves room for future
-  `WASIPreview2` / `WASIPreview3` classes the same way.
-- **Async-first providers.** Every provider method may return a Promise. The
-  WASI ↔ WASM bridge handles async the same way the current `stdin` path
-  handles blocking: main thread resolves, worker blocks on `SharedArrayBuffer`
-  + `Atomics.wait`. Sync returns remain valid.
-- **Clock and Random become providers.** Available from day one on
-  `WASIXContext`. Enables deterministic / reproducible execution. Potential
-  backport to `WASIContext` is out of scope for this work.
-- **ENOSYS by default.** Any WASIX syscall whose provider slot is empty
-  returns `ENOSYS`. A WASIX binary boots as long as it only uses calls whose
-  providers are wired up.
+- Full WASIX import surface (`wasix_32v1`, `wasix_64v1`) wired up.
+- Existing preview1 and unstable imports continue to work for WASIX binaries
+  (they import both).
+- Clock and Random become overridable providers (enables deterministic
+  execution).
+
+Nothing in WASIX is intrinsically out of scope: every syscall has a provider
+slot. Unwired slots return `ENOSYS`.
+
+**Non-goals.** Parity with Wasmer's WASIX runtime semantics. Real socket /
+fork / exec implementations inside the runtime. Those are host concerns.
 
 ## Public surface
 
+New root exports from `@runno/wasi`:
+
 ```ts
-// New root exports from @runno/wasi
 export { WASIX, WASIXContext, WASIXWorkerHost } from "./wasix/...";
+export type {
+  ClockProvider, RandomProvider,
+  TTYProvider, ThreadsProvider, FutexProvider,
+  SignalsProvider, SocketsProvider, ProcProvider,
+} from "./wasix/providers.js";
 ```
 
-Import namespaces served by `WASIX`:
+Existing `WASI`, `WASIContext`, `WASIWorkerHost`, and the
+`WASISnapshotPreview1` namespace export are unchanged. This keeps a clean slot
+for future `WASIPreview2` / `WASIPreview3` classes alongside.
 
-- `wasix_32v1` (32-bit)
-- `wasix_64v1` (memory64 binaries)
-- `wasi_snapshot_preview1` — serviced by the existing preview1 implementation
-  (reused, not duplicated). WASIX binaries typically import both.
-- `wasi_unstable` — same reason.
+## Architecture
 
-Existing `WASI` class and exports are unchanged.
+### Class structure
 
-## Provider catalog
+```
+                ┌─────────────────────┐
+                │  WASIDrive          │  emulated unix-like FS
+                └──────▲──────────────┘
+                       │ shared
+      ┌────────────────┴─────────────────┐
+      │                                  │
+┌───────────────┐                  ┌───────────────┐
+│  WASI         │                  │  WASIX        │
+│  (preview1 +  │  <── delegates ──│  (wasix_32v1 +│
+│   unstable)   │     preview1/    │   wasix_64v1) │
+│               │     unstable     │               │
+└───────────────┘                  └───────────────┘
+```
 
-All provider methods may be sync or async (return `T` or `Promise<T>`).
+`WASIX` does **not** subclass `WASI`. The two are siblings that share the
+drive abstraction (and a small set of memory-helper utilities extracted to a
+shared module). `WASIX` composes a `WASI` instance internally to service
+preview1/unstable imports, rather than inheriting. This keeps each class's
+surface narrow and makes future preview2/preview3 classes independent of
+WASIX.
+
+### Import object
+
+`WASIX.getImportObject()` returns:
+
+```ts
+{
+  wasix_32v1:             { …all WASIX syscalls, 32-bit pointers },
+  wasix_64v1:             { …same handlers, 64-bit pointer decode },
+  wasi_snapshot_preview1: <delegated to internal WASI>,
+  wasi_unstable:          <delegated to internal WASI>,
+}
+```
+
+A WASIX binary that imports both `wasix_32v1` and `wasi_snapshot_preview1`
+sees a consistent filesystem / env / stdio across the two, because both sets
+of handlers are backed by the same `WASIDrive` and `WASIXContext`.
+Memory is owned by the WASIX instance and passed to the internal WASI.
+
+`wasix_64v1` differs from `wasix_32v1` only in pointer width — handlers are
+shared; pointer decoding is parameterised.
+
+## Context & providers
 
 ```ts
 type WASIXContextOptions = {
-  // Same surface as WASIContext: fs, args, env, stdin, stdout, stderr, debug, isTTY
-  // plus:
+  // File / process basics — same semantics as WASIContext
+  fs: WASIFS;
+  args: string[];
+  env: Record<string, string>;
+  stdin: (maxByteLength: number) => string | null | Promise<string | null>;
+  stdout: (out: string) => void | Promise<void>;
+  stderr: (err: string) => void | Promise<void>;
+  isTTY: boolean;
+  debug?: DebugFn;
 
-  clock?:   ClockProvider;    // clock_time_get / clock_res_get — overridable for determinism
-  random?:  RandomProvider;   // random_get — overridable for reproducibility
-
+  // Providers — all optional, all async-capable
+  clock?:   ClockProvider;    // clock_time_get, clock_res_get
+  random?:  RandomProvider;   // random_get
   tty?:     TTYProvider;      // tty_get, tty_set
   threads?: ThreadsProvider;  // thread_spawn/join/exit/sleep/id/parallelism/signal
   futex?:   FutexProvider;    // futex_wait, futex_wake(_all)
   signals?: SignalsProvider;  // signal_register, proc_raise_interval
-  sockets?: SocketsProvider;  // full WASIX socket surface (TCP/UDP/resolve)
+  sockets?: SocketsProvider;  // WASIX socket surface (TCP/UDP/resolve)
   proc?:    ProcProvider;     // proc_id, proc_fork/spawn/exec/join, proc_parent
 };
 ```
 
-Interface sketches (finalised in PR 2):
+All provider methods may be sync or async. Every method uses JS-native shapes
+— `Uint8Array`, `bigint`, `Promise<T>`, plain objects for structured types
+like `SockAddr`. **Raw pointers never leave the `WASIX` class.**
+
+Example interface shapes (final forms pinned during implementation):
 
 ```ts
 interface ClockProvider {
-  now(id: ClockId): bigint | Promise<bigint>;        // nanoseconds since epoch / monotonic start
+  now(id: ClockId): bigint | Promise<bigint>;        // nanoseconds
   resolution(id: ClockId): bigint | Promise<bigint>;
 }
 
@@ -82,84 +136,153 @@ interface RandomProvider {
 }
 
 interface ThreadsProvider {
-  spawn(startArg: number): number | Promise<number>;
-  join(tid: number): number | Promise<number>;
+  spawn(startArg: number): number | Promise<number>;    // tid
+  join(tid: number): number | Promise<number>;          // exit code
   exit(code: number): void;
   sleep(durationNs: bigint): void | Promise<void>;
   id(): number;
   parallelism(): number;
+  signal(tid: number, signo: number): Result | Promise<Result>;
+}
+
+interface FutexProvider {
+  wait(addr: number, expected: number, timeoutNs: bigint | null)
+    : number | Promise<number>;
+  wake(addr: number, count: number): number | Promise<number>;
 }
 
 interface SocketsProvider {
   open(af: number, type: number, proto: number): number | Promise<number>;
   bind(fd: number, addr: SockAddr): Result | Promise<Result>;
   connect(fd: number, addr: SockAddr): Result | Promise<Result>;
-  send(fd: number, bufs: Uint8Array[], flags: number): number | Promise<number>;
-  recv(fd: number, bufs: Uint8Array[], flags: number): number | Promise<number>;
-  // …etc, 1:1 with WASIX socket calls
+  listen(fd: number, backlog: number): Result | Promise<Result>;
+  accept(fd: number): number | Promise<number>;
+  send(fd: number, bufs: Uint8Array[], flags: number)
+    : number | Promise<number>;
+  recv(fd: number, bufs: Uint8Array[], flags: number)
+    : SockRecvResult | Promise<SockRecvResult>;
+  shutdown(fd: number, how: number): Result | Promise<Result>;
+  addrResolve(host: string, port: number, hints: AddrHints)
+    : SockAddr[] | Promise<SockAddr[]>;
+  // …getsockopt/setsockopt, addr_local/peer, status
+}
+
+interface ProcProvider {
+  id(): number;
+  parentId(): number;
+  fork(): ProcForkResult | Promise<ProcForkResult>;
+  spawn(req: ProcSpawnRequest): number | Promise<number>;
+  exec(req: ProcExecRequest): Result | Promise<Result>;
+  join(pid: number): ProcExitInfo | Promise<ProcExitInfo>;
+}
+
+interface SignalsProvider {
+  register(signo: number, handler: number): Result | Promise<Result>;
+  raiseInterval(signo: number, intervalNs: bigint): Result | Promise<Result>;
+}
+
+interface TTYProvider {
+  get(): TTYState | Promise<TTYState>;       // cols, rows, pixel size, echo, line, raw, …
+  set(state: TTYState): Result | Promise<Result>;
 }
 ```
 
-Each provider method is expressed in JS-native shapes (`Uint8Array`, `bigint`,
-`Promise`) — never raw pointers. Memory marshalling lives in the `WASIX` class.
+## Async syscall bridge
 
-## Delivery plan
+All provider calls can return a Promise. On the main thread this is trivial —
+the `WASIX` class awaits before returning to the guest. Inside a
+`WASIXWorker`, the WASM guest is synchronous from its own point of view and
+needs a way to block until the host-side promise resolves.
 
-### PR 1 — WASIX scaffolding
+Mechanism — a generalised version of the existing `stdin` pattern:
 
-- New subtree `lib/wasix/`:
-  - `wasix.ts` — `WASIX` class
-  - `wasix-context.ts` — `WASIXContext` + provider types
-  - `wasix-abi.ts` — constants and type codes (1:1 with the WASIX C headers)
-  - `wasix-worker.ts` / `wasix-host.ts` — worker harness
-- New root exports; existing `WASI` untouched.
-- Register `wasix_32v1` + `wasix_64v1` import namespaces. Also register
-  `wasi_snapshot_preview1` and `wasi_unstable` — service these via the existing
-  preview1 implementation (reuse, don't duplicate).
-- Implement the WASIX calls that need no provider: `chdir`, `getcwd`,
-  `env_set` / `env_unset`, `fd_dup` / `fd_dup2` / `fd_pipe` / `fd_event`
-  (drive-level).
-- All other WASIX calls: `ENOSYS` passthroughs.
-- Basic test binary that boots and exits cleanly.
+1. The host allocates a `SharedArrayBuffer` once per worker; handed to the
+   worker at start-up.
+2. A syscall inside the worker whose provider returns a Promise: serialises
+   its opcode + arguments into a request region, signals the main thread
+   with `Atomics.notify`, then blocks on `Atomics.wait`.
+3. The main thread's `WASIXWorkerHost` sees the request, dispatches to the
+   appropriate provider, awaits the Promise, writes the serialised reply into
+   the response region, and notifies the worker.
+4. The worker wakes, deserialises the response, writes into WASM memory at
+   the original retptrs, and returns to the guest.
 
-### PR 2 — providers + async marshalling
+One request/response pair per worker is enough because the guest is
+single-threaded within its worker. When multiple TIDs run in separate workers
+(threading), each worker gets its own buffer.
 
-- Define and export every `*Provider` interface (including `ClockProvider` and
-  `RandomProvider`).
-- Generalise the existing `stdin` blocking pattern into a single
-  "await host response via `SharedArrayBuffer` + `Atomics.wait`" helper.
-  Every provider call routes through it.
-- For every WASIX syscall with a provider: read WASM memory → dispatch to
-  provider → await if Promise → write result back. No policy in the WASI layer.
-- Reference providers under `lib/wasix/providers/`:
-  - `FixedClockProvider`, `SeededRandomProvider` — deterministic defaults.
-  - `AtomicsFutexProvider` — if the host supplies shared memory.
-  - `MockSocketsProvider`, `MockThreadsProvider` — scripted, for tests.
-- TypeDoc for every interface.
+This replaces the bespoke `stdin` `SharedArrayBuffer` with a generic
+syscall-bridge protocol; `stdin` becomes one opcode among many.
 
-### PR 3 — examples, docs, coverage
+On the main thread (no worker), there is no bridge: `WASIX.start` is an async
+function that awaits provider Promises directly. The public API makes this
+explicit — `await WASIX.start(...)` vs `new WASIXWorkerHost(...)`.
 
-- Example WASIX programs exercising each provider slot (vendored binaries or
-  compiled via `wasix-libc`).
-- README: *"Runno emulates. You simulate."* explaining the pattern.
-- Worked example: threaded-Rust binary running against a cooperative
-  `ThreadsProvider` that schedules tasks round-robin on a single worker —
-  proving threads can be fully host-simulated without real `Worker`s.
+## Thread / memory model
 
-## Out of scope
+Threaded WASIX binaries expect:
+- A `wasi_thread_start(tid: i32, startArg: i32) -> ()` export on the module.
+- The module imports its memory (`env.memory`) rather than exporting it, and
+  that memory is declared `shared: true`.
 
-Nothing in WASIX is out of scope. Every syscall has a provider slot; unwired
-slots return `ENOSYS`. Hosts plug in as much or as little semantics as they
-need.
+The runtime's responsibility:
+- Construct (or accept from the host) a
+  `WebAssembly.Memory({ initial, maximum, shared: true })`.
+- Instantiate the main module against that memory.
+- On `thread_spawn(startArg)`, call `ThreadsProvider.spawn(startArg)` for a TID.
+
+The *semantics* of running the new thread are the provider's problem:
+
+- A real-worker provider instantiates a new worker, loads the same WASM module
+  against the same shared `Memory`, and calls `wasi_thread_start(tid, startArg)`.
+- A cooperative provider maintains a run queue on one worker and schedules
+  `wasi_thread_start` invocations cooperatively.
+- A mock provider returns a canned TID and never actually runs anything.
+
+The runtime ships a small optional helper, `lib/wasix/thread-start.ts`, that
+providers can use if they want the "real worker" path — handles memory
+import wiring, `wasi_thread_start` invocation, and exit reporting. Providers
+that model threads differently never touch it.
+
+## Determinism
+
+With `clock` and `random` as providers, a host can pin either or both for
+reproducibility:
+
+```ts
+const wasix = new WASIX({
+  clock:  new FixedClockProvider(0n),     // epoch 0, monotonic 0
+  random: new SeededRandomProvider(42),   // seeded PRNG
+  // …
+});
+```
+
+No provider supplied → runtime falls back to `Date.now()` and
+`crypto.getRandomValues()` — identical to today's `WASI` defaults.
+
+## Error model
+
+- Provider slot empty for a given syscall → return `Result.ENOSYS` without
+  ever invoking a provider.
+- Provider throws a `WASIXError` subclass → its `.result` is returned as the
+  syscall's errno.
+- Provider throws anything else → treated as a runtime error, logged via the
+  `debug` hook, syscall returns `Result.EIO`. The thrown value is **not**
+  propagated across the WASM boundary — the guest sees a normal errno, not a
+  thrown JS exception.
+- `proc_exit` and uncaught `WebAssembly.RuntimeError` keep their current
+  `WASI` behaviour (exit code, 134 respectively).
 
 ## Open questions
 
-- Exact interface shapes — pinned in PR 2.
-- Do we backport `ClockProvider` / `RandomProvider` to the existing `WASI`
-  class? Separate minor-version bump; non-blocking here.
-- Do we expose a `WASIPreview2` path now, or wait until a real 0.2 binary
-  surfaces? Leaning wait.
-- `proc_fork` / `proc_spawn` semantics: a host that wants to simulate these
-  needs some "pause and hand over state" concept. The provider probably
-  receives an opaque snapshot object and returns a child handle. Revisit
-  in PR 2 or later.
+- Exact ABI layout for each WASIX syscall — pinned during implementation
+  against the WASIX C headers.
+- `proc_fork` / `proc_spawn` provider shape: does the provider receive an
+  opaque snapshot of module state (so it could in principle continue execution
+  elsewhere) or just a notification with args? Leaning opaque-snapshot to keep
+  options open, but the shape needs worked examples before we commit.
+- Module init order when `env.memory` is host-supplied vs module-exported.
+  WASIX binaries vary; we need a clean story for both.
+- Do we expose the syscall-bridge opcodes publicly, so third parties can
+  implement providers out-of-process (e.g. over a websocket to a remote host)?
+  Attractive for future work; leave closed initially.

--- a/packages/wasi/WASIX-PLAN.md
+++ b/packages/wasi/WASIX-PLAN.md
@@ -1,0 +1,165 @@
+# WASIX support — plan
+
+*Status: in progress. Living document — revise as decisions land.*
+
+## Goal
+
+Support WASIX binaries in `@runno/wasi` using Runno's existing sandboxing
+philosophy: the runtime provides the marshalling between WASM memory and
+JavaScript; the host supplies the semantics via pluggable providers.
+
+> Runno emulates. You simulate.
+
+The runtime never performs a real syscall. For every WASIX capability, the host
+decides what "the world" looks like — a real `Worker`, a scripted scheduler, a
+recorded trace, a network simulator, `/dev/null`. Runno doesn't care.
+
+## Decisions
+
+- **Separate root export `WASIX`.** The existing `WASI` class and its
+  preview1/unstable behaviour are untouched. `WASIX` is a new class with its own
+  context, worker host, and import namespaces. This leaves room for future
+  `WASIPreview2` / `WASIPreview3` classes the same way.
+- **Async-first providers.** Every provider method may return a Promise. The
+  WASI ↔ WASM bridge handles async the same way the current `stdin` path
+  handles blocking: main thread resolves, worker blocks on `SharedArrayBuffer`
+  + `Atomics.wait`. Sync returns remain valid.
+- **Clock and Random become providers.** Available from day one on
+  `WASIXContext`. Enables deterministic / reproducible execution. Potential
+  backport to `WASIContext` is out of scope for this work.
+- **ENOSYS by default.** Any WASIX syscall whose provider slot is empty
+  returns `ENOSYS`. A WASIX binary boots as long as it only uses calls whose
+  providers are wired up.
+
+## Public surface
+
+```ts
+// New root exports from @runno/wasi
+export { WASIX, WASIXContext, WASIXWorkerHost } from "./wasix/...";
+```
+
+Import namespaces served by `WASIX`:
+
+- `wasix_32v1` (32-bit)
+- `wasix_64v1` (memory64 binaries)
+- `wasi_snapshot_preview1` — serviced by the existing preview1 implementation
+  (reused, not duplicated). WASIX binaries typically import both.
+- `wasi_unstable` — same reason.
+
+Existing `WASI` class and exports are unchanged.
+
+## Provider catalog
+
+All provider methods may be sync or async (return `T` or `Promise<T>`).
+
+```ts
+type WASIXContextOptions = {
+  // Same surface as WASIContext: fs, args, env, stdin, stdout, stderr, debug, isTTY
+  // plus:
+
+  clock?:   ClockProvider;    // clock_time_get / clock_res_get — overridable for determinism
+  random?:  RandomProvider;   // random_get — overridable for reproducibility
+
+  tty?:     TTYProvider;      // tty_get, tty_set
+  threads?: ThreadsProvider;  // thread_spawn/join/exit/sleep/id/parallelism/signal
+  futex?:   FutexProvider;    // futex_wait, futex_wake(_all)
+  signals?: SignalsProvider;  // signal_register, proc_raise_interval
+  sockets?: SocketsProvider;  // full WASIX socket surface (TCP/UDP/resolve)
+  proc?:    ProcProvider;     // proc_id, proc_fork/spawn/exec/join, proc_parent
+};
+```
+
+Interface sketches (finalised in PR 2):
+
+```ts
+interface ClockProvider {
+  now(id: ClockId): bigint | Promise<bigint>;        // nanoseconds since epoch / monotonic start
+  resolution(id: ClockId): bigint | Promise<bigint>;
+}
+
+interface RandomProvider {
+  fill(buf: Uint8Array): void | Promise<void>;
+}
+
+interface ThreadsProvider {
+  spawn(startArg: number): number | Promise<number>;
+  join(tid: number): number | Promise<number>;
+  exit(code: number): void;
+  sleep(durationNs: bigint): void | Promise<void>;
+  id(): number;
+  parallelism(): number;
+}
+
+interface SocketsProvider {
+  open(af: number, type: number, proto: number): number | Promise<number>;
+  bind(fd: number, addr: SockAddr): Result | Promise<Result>;
+  connect(fd: number, addr: SockAddr): Result | Promise<Result>;
+  send(fd: number, bufs: Uint8Array[], flags: number): number | Promise<number>;
+  recv(fd: number, bufs: Uint8Array[], flags: number): number | Promise<number>;
+  // …etc, 1:1 with WASIX socket calls
+}
+```
+
+Each provider method is expressed in JS-native shapes (`Uint8Array`, `bigint`,
+`Promise`) — never raw pointers. Memory marshalling lives in the `WASIX` class.
+
+## Delivery plan
+
+### PR 1 — WASIX scaffolding
+
+- New subtree `lib/wasix/`:
+  - `wasix.ts` — `WASIX` class
+  - `wasix-context.ts` — `WASIXContext` + provider types
+  - `wasix-abi.ts` — constants and type codes (1:1 with the WASIX C headers)
+  - `wasix-worker.ts` / `wasix-host.ts` — worker harness
+- New root exports; existing `WASI` untouched.
+- Register `wasix_32v1` + `wasix_64v1` import namespaces. Also register
+  `wasi_snapshot_preview1` and `wasi_unstable` — service these via the existing
+  preview1 implementation (reuse, don't duplicate).
+- Implement the WASIX calls that need no provider: `chdir`, `getcwd`,
+  `env_set` / `env_unset`, `fd_dup` / `fd_dup2` / `fd_pipe` / `fd_event`
+  (drive-level).
+- All other WASIX calls: `ENOSYS` passthroughs.
+- Basic test binary that boots and exits cleanly.
+
+### PR 2 — providers + async marshalling
+
+- Define and export every `*Provider` interface (including `ClockProvider` and
+  `RandomProvider`).
+- Generalise the existing `stdin` blocking pattern into a single
+  "await host response via `SharedArrayBuffer` + `Atomics.wait`" helper.
+  Every provider call routes through it.
+- For every WASIX syscall with a provider: read WASM memory → dispatch to
+  provider → await if Promise → write result back. No policy in the WASI layer.
+- Reference providers under `lib/wasix/providers/`:
+  - `FixedClockProvider`, `SeededRandomProvider` — deterministic defaults.
+  - `AtomicsFutexProvider` — if the host supplies shared memory.
+  - `MockSocketsProvider`, `MockThreadsProvider` — scripted, for tests.
+- TypeDoc for every interface.
+
+### PR 3 — examples, docs, coverage
+
+- Example WASIX programs exercising each provider slot (vendored binaries or
+  compiled via `wasix-libc`).
+- README: *"Runno emulates. You simulate."* explaining the pattern.
+- Worked example: threaded-Rust binary running against a cooperative
+  `ThreadsProvider` that schedules tasks round-robin on a single worker —
+  proving threads can be fully host-simulated without real `Worker`s.
+
+## Out of scope
+
+Nothing in WASIX is out of scope. Every syscall has a provider slot; unwired
+slots return `ENOSYS`. Hosts plug in as much or as little semantics as they
+need.
+
+## Open questions
+
+- Exact interface shapes — pinned in PR 2.
+- Do we backport `ClockProvider` / `RandomProvider` to the existing `WASI`
+  class? Separate minor-version bump; non-blocking here.
+- Do we expose a `WASIPreview2` path now, or wait until a real 0.2 binary
+  surfaces? Leaning wait.
+- `proc_fork` / `proc_spawn` semantics: a host that wants to simulate these
+  needs some "pause and hand over state" concept. The provider probably
+  receives an opaque snapshot object and returns a child handle. Revisit
+  in PR 2 or later.

--- a/packages/wasi/WASIX-PLAN.md
+++ b/packages/wasi/WASIX-PLAN.md
@@ -24,27 +24,27 @@ All of that is a host-side decision; the runtime is unaware.
   execution).
 - **Pass the upstream WASIX integration test suite
   ([`wasmerio/wasix-integration-tests`](https://github.com/wasmerio/wasix-integration-tests))**
-  under a reference provider configuration shipped with the package. See
+  using the simulation providers shipped with the package. See
   [Validation](#validation).
 
 Every WASIX syscall has a provider slot. Unwired slots return `ENOSYS`.
 
 **Non-goals.**
 
-- Tests requiring in-place resumption of WASM execution — principally
-  `proc_fork`, asynchronous (pre-empting) signal delivery, and cross-frame
-  `setjmp`/`longjmp`. These need the guest's call stack and program counter
-  to be reified from outside, which WebAssembly does not expose to JS.
-  Wasmer works around it with whole-module Asyncify instrumentation plus its
-  journaling runtime; a provider can't do either at call time. Tests that
-  depend on resume-after-fork are tracked as known-skipped. See
-  [Future: pause/resume support](#future-pauseresume-support) for the path
-  to lifting this.
+- Tests requiring Asyncify (or JSPI) instrumentation on the guest module —
+  principally `proc_fork` asserting on post-fork execution, asynchronously
+  delivered signals that pre-empt running code, and cross-frame
+  `setjmp`/`longjmp` across a JS-imported call. These need the guest's call
+  stack and program counter reified from outside, which WebAssembly does not
+  expose to JS. A provider can't supply that at call time. Tracked as
+  known-skipped. See [Future: Asyncify opt-in](#future-asyncify-opt-in) for
+  the path to lifting this.
 - `proc_exec` and `proc_spawn` are **not** in this category — they start a
   fresh instance, which a provider can do. Expected to pass.
-- Real socket / fork / exec implementations baked into the runtime. Those live
-  in providers — some of which Runno ships (enough to pass the suite), some of
-  which are the host's.
+- Real socket / process / thread implementations baked into the runtime *or*
+  shipped as Runno providers. Runno is a sandbox; its providers are
+  simulations. A host that wants real-world semantics wires its own
+  providers — Runno does not ship them.
 - `wasix_64v1` (Memory64 / wasm64). No existing toolchain output drives demand;
   the `wasix-libc` chain targets wasm32 in practice. Deferred — the handler
   code would mostly overlap with `wasix_32v1`, so picking it up later is cheap.
@@ -108,6 +108,18 @@ A WASIX binary that imports both `wasix_32v1` and `wasi_snapshot_preview1`
 sees a consistent filesystem / env / stdio across the two, because both sets
 of handlers are backed by the same `WASIDrive` and `WASIXContext`.
 Memory is owned by the WASIX instance and passed to the internal WASI.
+
+### ABI
+
+Mirrors the preview1 approach: `lib/wasix/wasix-32v1.ts` holds the ABI as
+TypeScript — enum members, flag masks, struct layouts, errno values — parallel
+to how `lib/wasi/snapshot-preview1.ts` defines preview1 today. The `WASIX`
+class reads from and writes to guest memory using those definitions; no raw
+magic numbers appear in the syscall handlers.
+
+Keeping the ABI in a dedicated module means a future `wasix_64v1` can reuse
+the same type definitions with wider pointer offsets, rather than forking the
+whole class.
 
 ## Context & providers
 
@@ -192,6 +204,11 @@ interface ProcProvider {
   join(pid: number): ProcExitInfo | Promise<ProcExitInfo>;
 }
 
+// fork / spawn / exec receive plain-data requests — opaque JS objects
+// containing the argv / env / fd table / memory snapshot the provider needs.
+// The provider never sees a live `WASIX` instance or the WebAssembly.Memory
+// directly; it decides on its own what "starting a new process" means.
+
 interface SignalsProvider {
   register(signo: number, handler: number): Result | Promise<Result>;
   raiseInterval(signo: number, intervalNs: bigint): Result | Promise<Result>;
@@ -260,6 +277,22 @@ providers can use if they want the "real worker" path — handles memory
 import wiring, `wasi_thread_start` invocation, and exit reporting. Providers
 that model threads differently never touch it.
 
+### Memory: auto-detect at load time
+
+WASIX binaries differ in whether they import or export memory. The runtime
+inspects the compiled module's imports before instantiation:
+
+- `env.memory` present in imports → runtime constructs a
+  `WebAssembly.Memory({ initial, maximum, shared })` matching the declared
+  limits and passes it in. `shared` follows the import's shared flag.
+- Otherwise → runtime lets the module export its memory and reads it from
+  `instance.exports.memory` after instantiation.
+
+A host can override auto-detection by passing `WASIXContextOptions.memory`
+(e.g. to reuse a shared `WebAssembly.Memory` across sibling workers in a
+threaded configuration). If supplied, it must satisfy whichever mode the
+module expects.
+
 ## Determinism
 
 With `clock` and `random` as providers, a host can pin either or both for
@@ -283,51 +316,61 @@ the upstream WASIX integration suite.
 
 This shapes the design in two concrete ways.
 
-### Reference providers ship with the package
+### Simulation providers ship with the package
 
-To run the suite end-to-end, a consuming host needs working threads, futex,
-sockets, TTY, signals, clock, and random semantics. The runtime alone cannot
-supply those (it's the sandbox — it never does real work). So the package
-ships two provider tiers:
+The runtime has no semantics of its own. To run the upstream suite end-to-end,
+the package ships a set of **simulation** providers — in-process, sandboxed,
+self-contained. They are not "reference implementations" of real Linux-style
+semantics; they model just enough behaviour to satisfy the test harness
+without ever touching a real socket, real process, or real OS thread.
 
 ```
 lib/wasix/providers/
-├── reference/      real-world semantics, enough to pass the upstream suite
-│   ├── worker-threads.ts        real Worker-backed ThreadsProvider
-│   ├── atomics-futex.ts         Atomics.wait/notify on shared memory
-│   ├── node-sockets.ts          node:net / node:dgram SocketsProvider (node only)
-│   ├── ws-proxy-sockets.ts      WebSocket-proxy SocketsProvider (browser)
-│   ├── system-clock.ts          Date.now() / performance.now()
-│   ├── web-crypto-random.ts     crypto.getRandomValues()
-│   ├── passthrough-tty.ts       reflects WASIXContext.isTTY + reasonable winsize
-│   └── self-signal.ts           signal_register + in-process dispatch
-└── deterministic/  test-friendly providers
-    ├── fixed-clock.ts
-    ├── seeded-random.ts
-    ├── mock-sockets.ts
-    ├── mock-threads.ts
-    └── …
+├── cooperative-threads.ts   cooperative scheduler, single worker, no preemption
+├── simulated-futex.ts       in-memory wait queues keyed by address
+├── loopback-sockets.ts      in-process TCP/UDP fabric; connects speak to peers
+│                            registered in the same WASIX instance
+├── passthrough-tty.ts       reflects WASIXContext.isTTY + canned winsize
+├── self-signal.ts           signal_register + in-process dispatch
+├── in-process-proc.ts       proc_spawn / proc_exec launch new WASIX instances
+│                            in the same JS realm; proc_join awaits their result
+├── system-clock.ts          Date.now() / performance.now() — overridable
+└── system-random.ts         crypto.getRandomValues() — overridable
 ```
 
-Both tiers are exported publicly but importing is opt-in — nothing is wired
-into `WASIXContext` by default. The integration suite runner configures a
-`WASIX` instance with the `reference/` providers; a unit test can use
-`deterministic/` providers or its own fakes.
+Every file above is importable on its own. Nothing is wired into
+`WASIXContext` by default — the host picks providers explicitly. The
+integration suite runner configures a `WASIX` instance from this set; a unit
+test can swap in a `FixedClockProvider`, a `SeededRandomProvider`, or its own
+fakes.
 
-This keeps the "Runno emulates, you simulate" design intact: the runtime has
-no semantics; the *reference providers* do, and they're just one possible
-host configuration among many.
+This is the design point: *simulations are enough to pass the suite.* The
+tests exercise API shape and errno behaviour, not real-world networking or
+real OS process semantics. A host that needs real behaviour plugs in its own
+providers (e.g. a `node-sockets.ts` backed by `node:net`) — but Runno doesn't
+ship those, because Runno is a sandbox.
 
 ### Known-skipped tests
 
-A small set of tests depends on resuming WASM execution at a specific frame
-from the outside — principally `proc_fork`, asynchronous signal pre-emption,
-and cross-frame `setjmp`/`longjmp`. See [the reasoning below](#why-those-tests-cant-be-passed-by-providers-alone)
-for why these aren't achievable with a provider alone. The test harness
-carries an explicit skip list with a one-line justification per entry. Any
-test that *can* be made to pass with sufficiently capable providers —
-including `proc_exec`, `proc_spawn`, threads, futex, sockets, and TTY — is
-not in this list.
+**Skip rule: a test is skipped iff it requires Asyncify (or JSPI)
+instrumentation on the guest module.** No other reason justifies a skip. If
+a simulation provider can be written to make a test pass, we write one.
+
+In practice that rule carves out exactly three categories:
+
+- `proc_fork` asserting on post-fork guest execution.
+- Asynchronous signal pre-emption — a signal delivered from outside the
+  guest's current call, pre-empting running code mid-frame.
+- Cross-frame `setjmp`/`longjmp` across a JS-imported call.
+
+See [the reasoning below](#why-those-tests-cant-be-passed-by-providers-alone)
+for why these three need Asyncify. Everything else — `proc_exec`,
+`proc_spawn`, threads, futex, sockets, TTY, self-raised signals at yield
+points, clocks, random — is implementable with simulation providers and
+expected to pass.
+
+The test harness carries an explicit skip list with a one-line
+"requires-Asyncify" justification per entry.
 
 ### Why those tests can't be passed by providers alone
 
@@ -369,13 +412,13 @@ The same limitation hits two related syscalls:
 In all three, the root cause is identical: **WASM execution state is not
 reifiable from JS**.
 
-Both workarounds described in [Future: pause/resume support](#future-pauseresume-support)
+Both workarounds described in [Future: Asyncify opt-in](#future-asyncify-opt-in)
 operate below the provider layer. Asyncify moves the stack *into* guest
 memory where JS can see it; JSPI adds a first-class pause/resume primitive
 at the engine. Neither is something a provider can do at call time — which
 is why v1 ships with these tests skipped rather than working around them.
 
-### Future: pause/resume support
+### Future: Asyncify opt-in
 
 The fork/pre-emption limitation is not permanent. Two paths lift it without
 changing the provider API:
@@ -392,10 +435,12 @@ provider capability bit. Out of scope for v1.
 
 ### CI
 
-The integration suite runs in CI against both provider configurations:
-- Node — `reference/` + `node-sockets`.
-- Browser (Playwright, COOP/COEP) — `reference/` + `ws-proxy-sockets` backed
-  by a local proxy started for the test run.
+One provider configuration — the simulation set from
+[Simulation providers ship with the package](#simulation-providers-ship-with-the-package) —
+runs in CI against both Node and browser (Playwright, COOP/COEP). Because
+the sockets provider is loopback-only and all processes live in the same JS
+realm, there is nothing environment-specific to branch on. Both runs execute
+the same suite minus the Asyncify-only skip list.
 
 ## Error model
 
@@ -412,16 +457,7 @@ The integration suite runs in CI against both provider configurations:
 
 ## Open questions
 
-- Exact ABI layout for each WASIX syscall — pinned during implementation
-  against the WASIX C headers.
-- `proc_fork` / `proc_spawn` provider shape: does the provider receive an
-  opaque snapshot of module state (so it could in principle continue execution
-  elsewhere) or just a notification with args? Leaning opaque-snapshot to keep
-  options open, but the shape needs worked examples before we commit.
-- Module init order when `env.memory` is host-supplied vs module-exported.
-  WASIX binaries vary; we need a clean story for both.
-- Do we expose the syscall-bridge opcodes publicly, so third parties can
-  implement providers out-of-process (e.g. over a websocket to a remote host)?
-  Attractive for future work; leave closed initially.
+- Exact ABI values and struct layouts for each WASIX syscall — pinned during
+  implementation against the WASIX C headers into `lib/wasix/wasix-32v1.ts`.
 - Exact skip list from `wasix-integration-tests`. Enumerate once the runtime
-  boots the suite end-to-end; revisit per test rather than guessing ahead.
+  boots the suite end-to-end and apply the "requires Asyncify" rule per test.

--- a/packages/wasi/WASIX-PLAN.md
+++ b/packages/wasi/WASIX-PLAN.md
@@ -522,6 +522,43 @@ the same suite minus the Asyncify-only skip list.
 - `proc_exit` and uncaught `WebAssembly.RuntimeError` keep their current
   `WASI` behaviour (exit code, 134 respectively).
 
+## Follow-up: refactor WASI to the provider model
+
+The two-tier provider shape applies cleanly to the existing preview1 +
+unstable implementation. Recommended as a follow-up PR once WASIX lands
+and validates the pattern in anger.
+
+What moves:
+
+- `WASIContext`'s `stdin` / `stdout` / `stderr` callbacks → `ConsoleTTYProvider`.
+- `WASIDrive` (currently internal) → `FileSystemProvider`, promoted to
+  a public ergonomic provider. Internal consumers switch to calling through
+  the provider.
+- Hard-coded `Date.now()` / `crypto.getRandomValues()` inside `WASI` →
+  `ClockProvider` / `RandomProvider` with the same defaults. Determinism
+  knob comes along for free.
+- preview1's `sock_*` family (`send`, `recv`, `shutdown` on accepted fds) →
+  served by the same `SocketsProvider`, so `HTTPProvider` works for WASI
+  too.
+
+Why it's worth doing:
+
+- One extension-point model across preview1, unstable, and wasix_32v1.
+  Fewer concepts for hosts to learn.
+- `HTTPProvider`, `FileSystemProvider`, `ConsoleTTYProvider`, and the
+  determinism knobs become available to existing Runno demos without
+  opting into WASIX.
+- The `WASI` and `WASIX` classes stop being asymmetric siblings — both
+  sit on the same provider substrate, only the import surface differs.
+
+Backward compatibility: the current `WASIContext` surface stays as a
+convenience shim that constructs the equivalent providers internally. No
+host code breaks; hosts that want the new model opt in explicitly.
+
+Sequencing: WASIX first because it's what forces the provider shape. Once
+WASIX ships and the provider set is stable, the refactor mirrors the same
+substrate backward into WASI in its own PR.
+
 ## Open questions
 
 - Exact ABI values and struct layouts for each WASIX syscall — pinned during

--- a/packages/wasi/WASIX-PLAN.md
+++ b/packages/wasi/WASIX-PLAN.md
@@ -31,12 +31,17 @@ Every WASIX syscall has a provider slot. Unwired slots return `ENOSYS`.
 
 **Non-goals.**
 
-- Tests requiring whole-module state snapshot semantics (`proc_fork`,
-  `proc_exec` that continue execution with a mutated memory image). Wasmer's
-  implementation uses its journaling/snapshot machinery for these; Runno's
-  provider model gives the host an opaque snapshot handle but does not itself
-  implement snapshot-and-resume. Specific tests dependent on that are tracked
-  as known-skipped.
+- Tests requiring in-place resumption of WASM execution — principally
+  `proc_fork`, asynchronous (pre-empting) signal delivery, and cross-frame
+  `setjmp`/`longjmp`. These need the guest's call stack and program counter
+  to be reified from outside, which WebAssembly does not expose to JS.
+  Wasmer works around it with whole-module Asyncify instrumentation plus its
+  journaling runtime; a provider can't do either at call time. Tests that
+  depend on resume-after-fork are tracked as known-skipped. See
+  [Future: pause/resume support](#future-pauseresume-support) for the path
+  to lifting this.
+- `proc_exec` and `proc_spawn` are **not** in this category — they start a
+  fresh instance, which a provider can do. Expected to pass.
 - Real socket / fork / exec implementations baked into the runtime. Those live
   in providers — some of which Runno ships (enough to pass the suite), some of
   which are the host's.
@@ -315,13 +320,29 @@ host configuration among many.
 
 ### Known-skipped tests
 
-A small set of tests depends on WASIX semantics that Runno's provider model
-cannot meaningfully simulate without implementing Wasmer-style journaling in
-the runtime itself — principally those exercising `proc_fork` / `proc_exec`
-that then assert on continued execution with a mutated memory image. These
-will be enumerated in a skip list in the test harness, with a one-line
-justification each. Any test that *can* be made to pass with sufficiently
-capable providers is not in this list.
+A small set of tests depends on resuming WASM execution at a specific frame
+from the outside — principally `proc_fork`, asynchronous signal pre-emption,
+and cross-frame `setjmp`/`longjmp`. See the non-goals section above for why
+these aren't achievable with a provider alone. The test harness carries an
+explicit skip list with a one-line justification per entry. Any test that
+*can* be made to pass with sufficiently capable providers — including
+`proc_exec`, `proc_spawn`, threads, futex, sockets, and TTY — is not in
+this list.
+
+### Future: pause/resume support
+
+The fork/pre-emption limitation is not permanent. Two paths lift it without
+changing the provider API:
+
+1. **Asyncify opt-in.** Users asyncify their WASIX binary at build time (or
+   Runno runs the Binaryen pass at load time behind a flag). Providers gain
+   a pause/resume hook that uses Asyncify's save/restore to unwind and
+   re-enter the guest. `proc_fork` becomes a provider-implementable syscall.
+2. **JS Promise Integration (JSPI).** Once JSPI is widely available, it
+   supplies the same pause/resume capability without module rewriting.
+
+Either is additive: a new optional flag on `WASIXContextOptions`, a new
+provider capability bit. Out of scope for v1.
 
 ### CI
 

--- a/packages/wasi/WASIX-PLAN.md
+++ b/packages/wasi/WASIX-PLAN.md
@@ -17,17 +17,23 @@ All of that is a host-side decision; the runtime is unaware.
 
 ## Scope
 
-- Full WASIX import surface (`wasix_32v1`, `wasix_64v1`) wired up.
+- WASIX `wasix_32v1` import namespace fully wired up.
 - Existing preview1 and unstable imports continue to work for WASIX binaries
   (they import both).
 - Clock and Random become overridable providers (enables deterministic
   execution).
 
-Nothing in WASIX is intrinsically out of scope: every syscall has a provider
-slot. Unwired slots return `ENOSYS`.
+Every WASIX syscall has a provider slot. Unwired slots return `ENOSYS`.
 
-**Non-goals.** Parity with Wasmer's WASIX runtime semantics. Real socket /
-fork / exec implementations inside the runtime. Those are host concerns.
+**Non-goals.**
+
+- Parity with Wasmer's WASIX runtime semantics. Runno is a sandbox; behaviour
+  is whatever the host models.
+- Real socket / fork / exec implementations inside the runtime. Those are
+  host concerns.
+- `wasix_64v1` (Memory64 / wasm64). No existing toolchain output drives demand;
+  the `wasix-libc` chain targets wasm32 in practice. Deferred — the handler
+  code would mostly overlap with `wasix_32v1`, so picking it up later is cheap.
 
 ## Public surface
 
@@ -78,8 +84,7 @@ WASIX.
 
 ```ts
 {
-  wasix_32v1:             { …all WASIX syscalls, 32-bit pointers },
-  wasix_64v1:             { …same handlers, 64-bit pointer decode },
+  wasix_32v1:             { …all WASIX syscalls },
   wasi_snapshot_preview1: <delegated to internal WASI>,
   wasi_unstable:          <delegated to internal WASI>,
 }
@@ -89,9 +94,6 @@ A WASIX binary that imports both `wasix_32v1` and `wasi_snapshot_preview1`
 sees a consistent filesystem / env / stdio across the two, because both sets
 of handlers are backed by the same `WASIDrive` and `WASIXContext`.
 Memory is owned by the WASIX instance and passed to the internal WASI.
-
-`wasix_64v1` differs from `wasix_32v1` only in pointer width — handlers are
-shared; pointer decoding is parameterised.
 
 ## Context & providers
 


### PR DESCRIPTION
## Summary

- Adds `packages/wasi/WASIX-PLAN.md` — a living technical design for WASIX support in `@runno/wasi`.
- Preserves the sandbox philosophy: runtime marshals, host-side providers simulate. No real syscalls are performed by the runtime.
- Scopes v1 to `wasix_32v1`; `wasix_64v1` is deferred (cheap to pick up later — same handlers, wider offsets).
- Correctness bar: pass [`wasmerio/wasix-integration-tests`](https://github.com/wasmerio/wasix-integration-tests) using the simulation providers shipped with the package.
- Skip rule: a test is skipped iff it requires Asyncify (or JSPI) instrumentation — covers `proc_fork` post-fork execution, async signal pre-emption, cross-frame `setjmp`/`longjmp`. Asyncify opt-in is the documented lift path.
- Sibling `WASIX` class (does not subclass `WASI`), new root exports: `WASIX`, `WASIXContext`, `WASIXWorkerHost`, plus provider interfaces.
- Async-first providers across the board; a generalised `SharedArrayBuffer` + `Atomics` bridge replaces the bespoke `stdin` protocol inside the worker.
- `Clock` and `Random` become overridable providers (unlocks deterministic execution).

This PR is the design artifact — no code yet. Use it as the review surface for the plan; implementation PRs will land against it.

## Test plan

- [ ] Read-through for architectural coherence (class structure, import object, context/providers).
- [ ] Sanity-check the simulation-providers list — does it cover everything the upstream suite needs?
- [ ] Confirm the Asyncify-only skip rule is the right gate (no other skip justifications sneak in).
- [ ] Validate the memory auto-detect story against known WASIX binaries (import vs export memory).
- [ ] Review the `ProcProvider` plain-data request shape before it gets locked in during implementation.