### PR TITLE
playwright: disable HTML reporter auto-open

### DIFF
--- a/packages/runtime/playwright.config.ts
+++ b/packages/runtime/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: "html",
+  reporter: [["html", { open: "never" }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/packages/wasi/playwright.config.ts
+++ b/packages/wasi/playwright.config.ts
@@ -30,7 +30,7 @@ const config: PlaywrightTestConfig = {
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: "html",
+  reporter: [["html", { open: "never" }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */


### PR DESCRIPTION
## Summary
Change both `playwright.config.ts` files (`packages/runtime`, `packages/wasi`) from `reporter: "html"` to `reporter: [["html", { open: "never" }]]`.

## Why
On macOS the default `html` reporter auto-opens the report by spawning `open --wait-apps <url>`, which blocks until the launched browser exits. For anyone running Playwright non-interactively (CI runners without `CI=1`, agent-driven shells, background tooling), the invoking shell never returns — the process just hangs on the `open --wait-apps` child.

With `open: "never"` the report is still generated on disk and can be viewed manually via `npx playwright show-report`; Playwright just won't auto-launch a browser on completion.

## Test plan
- [x] Run `npx playwright test` in `packages/wasi` — run finishes, shell returns, no browser auto-launched.
- [x] Run `npx playwright show-report` — report still renders.
- [x] Same for `packages/runtime`.