### PR TITLE
Slice 2 — Clock + Random providers

### DIFF
--- a/.github/workflows/test-on-pull-request.yml
+++ b/.github/workflows/test-on-pull-request.yml
@@ -12,6 +12,11 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: "22"
+      - name: Install wabt (wat2wasm)
+        # `packages/wasi`'s `build:tests:wat` step needs wat2wasm to compile
+        # the hand-written WAT smoke binaries (added in Slice 2) and the
+        # Slice 4 bridge unit-test binary into wasm before Playwright runs.
+        run: sudo apt-get update && sudo apt-get install -y wabt
       - name: Install dependencies
         run: npm run bootstrap
       - name: Build Runno

--- a/packages/wasi/lib/main.ts
+++ b/packages/wasi/lib/main.ts
@@ -8,6 +8,10 @@ export * as WASISnapshotPreview1 from "./wasi/snapshot-preview1.js";
 export * from "./wasix/wasix.js";
 export * from "./wasix/wasix-context.js";
 export * as WASIX32v1 from "./wasix/wasix-32v1.js";
+export { SystemClockProvider } from "./wasix/providers/system-clock.js";
+export { SystemRandomProvider } from "./wasix/providers/system-random.js";
+export { FixedClockProvider } from "./wasix/providers/fixed-clock.js";
+export { SeededRandomProvider } from "./wasix/providers/seeded-random.js";
 export type {
   ClockProvider,
   RandomProvider,

--- a/packages/wasi/lib/wasix/providers/fixed-clock.ts
+++ b/packages/wasi/lib/wasix/providers/fixed-clock.ts
@@ -8,7 +8,7 @@
 // CPU-time clocks (PROCESS_CPUTIME, THREAD_CPUTIME) share the monotonic
 // counter and increment the same way.
 
-import { ClockId } from "../wasix-32v1.js";
+import { ClockId, Result, WASIXError } from "../wasix-32v1.js";
 import type { ClockProvider } from "../providers.js";
 
 export class FixedClockProvider implements ClockProvider {
@@ -33,10 +33,20 @@ export class FixedClockProvider implements ClockProvider {
         this.counter += this.tick;
         return value;
       }
+      default:
+        throw new WASIXError(Result.EINVAL);
     }
   }
 
-  resolution(_id: ClockId): bigint {
-    return this.tick > 0n ? this.tick : 1n;
+  resolution(id: ClockId): bigint {
+    switch (id) {
+      case ClockId.REALTIME:
+      case ClockId.MONOTONIC:
+      case ClockId.PROCESS_CPUTIME:
+      case ClockId.THREAD_CPUTIME:
+        return this.tick > 0n ? this.tick : 1n;
+      default:
+        throw new WASIXError(Result.EINVAL);
+    }
   }
 }

--- a/packages/wasi/lib/wasix/providers/fixed-clock.ts
+++ b/packages/wasi/lib/wasix/providers/fixed-clock.ts
@@ -1,0 +1,42 @@
+// FixedClockProvider: deterministic clock for testing and simulation.
+//
+// REALTIME always returns `epochNs`.
+// MONOTONIC starts at `epochNs` and advances by `tick` nanoseconds on each
+// call. With the default tick of 0n the monotonic clock is frozen — useful
+// for deterministic replay. Set tick > 0n to simulate time passing between
+// calls (e.g. tick=1_000_000n advances 1ms per call).
+// CPU-time clocks (PROCESS_CPUTIME, THREAD_CPUTIME) share the monotonic
+// counter and increment the same way.
+
+import { ClockId } from "../wasix-32v1.js";
+import type { ClockProvider } from "../providers.js";
+
+export class FixedClockProvider implements ClockProvider {
+  private readonly epochNs: bigint;
+  private readonly tick: bigint;
+  private counter: bigint;
+
+  constructor(epochNs: bigint = 0n, tick: bigint = 0n) {
+    this.epochNs = epochNs;
+    this.tick = tick;
+    this.counter = 0n;
+  }
+
+  now(id: ClockId): bigint {
+    switch (id) {
+      case ClockId.REALTIME:
+        return this.epochNs;
+      case ClockId.MONOTONIC:
+      case ClockId.PROCESS_CPUTIME:
+      case ClockId.THREAD_CPUTIME: {
+        const value = this.epochNs + this.counter;
+        this.counter += this.tick;
+        return value;
+      }
+    }
+  }
+
+  resolution(_id: ClockId): bigint {
+    return this.tick > 0n ? this.tick : 1n;
+  }
+}

--- a/packages/wasi/lib/wasix/providers/seeded-random.ts
+++ b/packages/wasi/lib/wasix/providers/seeded-random.ts
@@ -1,0 +1,47 @@
+// SeededRandomProvider: deterministic PRNG for testing and simulation.
+//
+// Uses SFC32 (Small Fast Counting, 32-bit variant) — a high-quality PRNG
+// whose output depends only on integer arithmetic, making it identical across
+// all JavaScript engines. The algorithm is fully specified as:
+//   t = (a + b + counter) >>> 0
+//   counter = (counter + 1) >>> 0
+//   a = b ^ (b >>> 9)
+//   b = (c + (c << 3)) >>> 0
+//   c = rotl32(c, 21) + t >>> 0
+// Fifteen warm-up rounds are run after seeding to disperse low-entropy seeds.
+
+import type { RandomProvider } from "../providers.js";
+
+export class SeededRandomProvider implements RandomProvider {
+  private a: number;
+  private b: number;
+  private c: number;
+  private counter: number;
+
+  constructor(seed: number) {
+    this.a = seed >>> 0;
+    this.b = seed >>> 0;
+    this.c = seed >>> 0;
+    this.counter = 1;
+    for (let i = 0; i < 15; i++) this.next();
+  }
+
+  private next(): number {
+    const t = (this.a + this.b + this.counter) >>> 0;
+    this.counter = (this.counter + 1) >>> 0;
+    this.a = this.b ^ (this.b >>> 9);
+    this.b = (this.c + (this.c << 3)) >>> 0;
+    this.c = (((this.c << 21) | (this.c >>> 11)) + t) >>> 0;
+    return t;
+  }
+
+  fill(buf: Uint8Array): void {
+    for (let i = 0; i < buf.length; i += 4) {
+      const v = this.next();
+      buf[i] = v & 0xff;
+      if (i + 1 < buf.length) buf[i + 1] = (v >>> 8) & 0xff;
+      if (i + 2 < buf.length) buf[i + 2] = (v >>> 16) & 0xff;
+      if (i + 3 < buf.length) buf[i + 3] = (v >>> 24) & 0xff;
+    }
+  }
+}

--- a/packages/wasi/lib/wasix/providers/system-clock.ts
+++ b/packages/wasi/lib/wasix/providers/system-clock.ts
@@ -2,7 +2,7 @@
 // CPU-time clocks (PROCESS_CPUTIME, THREAD_CPUTIME) fall back to monotonic —
 // fine-grained CPU accounting is unavailable in the browser sandbox.
 
-import { ClockId } from "../wasix-32v1.js";
+import { ClockId, Result, WASIXError } from "../wasix-32v1.js";
 import type { ClockProvider } from "../providers.js";
 
 export class SystemClockProvider implements ClockProvider {
@@ -14,6 +14,8 @@ export class SystemClockProvider implements ClockProvider {
       case ClockId.PROCESS_CPUTIME:
       case ClockId.THREAD_CPUTIME:
         return BigInt(Math.floor(performance.now() * 1_000_000));
+      default:
+        throw new WASIXError(Result.EINVAL);
     }
   }
 
@@ -25,6 +27,8 @@ export class SystemClockProvider implements ClockProvider {
       case ClockId.PROCESS_CPUTIME:
       case ClockId.THREAD_CPUTIME:
         return 1_000n; // ~1µs (approximate; browser may clamp higher)
+      default:
+        throw new WASIXError(Result.EINVAL);
     }
   }
 }

--- a/packages/wasi/lib/wasix/providers/system-clock.ts
+++ b/packages/wasi/lib/wasix/providers/system-clock.ts
@@ -1,0 +1,30 @@
+// SystemClockProvider: browser-native clock using Date.now() and performance.now().
+// CPU-time clocks (PROCESS_CPUTIME, THREAD_CPUTIME) fall back to monotonic —
+// fine-grained CPU accounting is unavailable in the browser sandbox.
+
+import { ClockId } from "../wasix-32v1.js";
+import type { ClockProvider } from "../providers.js";
+
+export class SystemClockProvider implements ClockProvider {
+  now(id: ClockId): bigint {
+    switch (id) {
+      case ClockId.REALTIME:
+        return BigInt(Date.now()) * 1_000_000n;
+      case ClockId.MONOTONIC:
+      case ClockId.PROCESS_CPUTIME:
+      case ClockId.THREAD_CPUTIME:
+        return BigInt(Math.floor(performance.now() * 1_000_000));
+    }
+  }
+
+  resolution(id: ClockId): bigint {
+    switch (id) {
+      case ClockId.REALTIME:
+        return 1_000_000n; // ~1ms
+      case ClockId.MONOTONIC:
+      case ClockId.PROCESS_CPUTIME:
+      case ClockId.THREAD_CPUTIME:
+        return 1_000n; // ~1µs (approximate; browser may clamp higher)
+    }
+  }
+}

--- a/packages/wasi/lib/wasix/providers/system-random.ts
+++ b/packages/wasi/lib/wasix/providers/system-random.ts
@@ -1,0 +1,15 @@
+// SystemRandomProvider: browser-native random using crypto.getRandomValues.
+// Processes the buffer in 65536-byte chunks (the maximum chunk size accepted
+// by crypto.getRandomValues per call).
+
+import type { RandomProvider } from "../providers.js";
+
+const MAX_CHUNK = 65536;
+
+export class SystemRandomProvider implements RandomProvider {
+  fill(buf: Uint8Array): void {
+    for (let offset = 0; offset < buf.length; offset += MAX_CHUNK) {
+      crypto.getRandomValues(buf.subarray(offset, offset + MAX_CHUNK));
+    }
+  }
+}

--- a/packages/wasi/lib/wasix/wasix-32v1.ts
+++ b/packages/wasi/lib/wasix/wasix-32v1.ts
@@ -127,3 +127,15 @@ export enum Signal {
   SIGPWR = 30,
   SIGSYS = 31,
 }
+
+// ─── Error class ─────────────────────────────────────────────────────────────
+
+// Thrown by provider implementations to signal a specific WASIX errno.
+// WASIX catches this and returns result directly; any other throw → EIO.
+export class WASIXError extends Error {
+  readonly result: Result;
+  constructor(result: Result, message?: string) {
+    super(message ?? `WASIXError: ${Result[result]}`);
+    this.result = result;
+  }
+}

--- a/packages/wasi/lib/wasix/wasix.ts
+++ b/packages/wasi/lib/wasix/wasix.ts
@@ -1,4 +1,4 @@
-import { Result } from "./wasix-32v1.js";
+import { ClockId, Result, WASIXError } from "./wasix-32v1.js";
 import { WASIXContext, WASIXContextOptions } from "./wasix-context.js";
 import {
   WASI,
@@ -6,6 +6,9 @@ import {
   InitializationError,
 } from "../wasi/wasi.js";
 import { WASIXExecutionResult } from "../types.js";
+import { SystemClockProvider } from "./providers/system-clock.js";
+import { SystemRandomProvider } from "./providers/system-random.js";
+import type { ClockProvider, RandomProvider } from "./providers.js";
 
 class WASIXExit extends Error {
   code: number;
@@ -35,6 +38,8 @@ export class WASIX {
   hasBeenInitialized: boolean = false;
 
   private wasi: WASI;
+  private _clock?: ClockProvider;
+  private _random?: RandomProvider;
 
   /**
    * Start a WASIX command.
@@ -143,8 +148,66 @@ export class WASIX {
   }
 
   //
-  // wasix_32v1 stubs — all return ENOSYS this slice.
+  // Provider accessors — lazy-init system defaults when context slot is unset.
   //
+
+  private get clock(): ClockProvider {
+    return this.context.clock ?? (this._clock ??= new SystemClockProvider());
+  }
+
+  private get random(): RandomProvider {
+    return this.context.random ?? (this._random ??= new SystemRandomProvider());
+  }
+
+  //
+  // wasix_32v1 syscall handlers — clock + random wired; all others ENOSYS.
+  //
+
+  private wasix_clock_time_get(
+    id: number,
+    _precision: bigint,
+    retptr: number,
+  ): number {
+    try {
+      const view = new DataView(this.memory.buffer);
+      view.setBigUint64(retptr, this.clock.now(id as ClockId), true);
+      return Result.SUCCESS;
+    } catch (e) {
+      if (e instanceof WASIXError) return e.result;
+      this.context.debug?.("clock_time_get", [], Result.EIO, [
+        { error: String(e) },
+      ]);
+      return Result.EIO;
+    }
+  }
+
+  private wasix_clock_res_get(id: number, retptr: number): number {
+    try {
+      const view = new DataView(this.memory.buffer);
+      view.setBigUint64(retptr, this.clock.resolution(id as ClockId), true);
+      return Result.SUCCESS;
+    } catch (e) {
+      if (e instanceof WASIXError) return e.result;
+      this.context.debug?.("clock_res_get", [], Result.EIO, [
+        { error: String(e) },
+      ]);
+      return Result.EIO;
+    }
+  }
+
+  private wasix_random_get(bufPtr: number, bufLen: number): number {
+    try {
+      const buf = new Uint8Array(this.memory.buffer, bufPtr, bufLen);
+      this.random.fill(buf);
+      return Result.SUCCESS;
+    } catch (e) {
+      if (e instanceof WASIXError) return e.result;
+      this.context.debug?.("random_get", [], Result.EIO, [
+        { error: String(e) },
+      ]);
+      return Result.EIO;
+    }
+  }
 
   private getWasix32v1Stubs(): WebAssembly.ModuleImports {
     const enosys = () => Result.ENOSYS;
@@ -156,8 +219,8 @@ export class WASIX {
       environ_sizes_get: enosys,
 
       // Clock
-      clock_res_get: enosys,
-      clock_time_get: enosys,
+      clock_res_get: this.wasix_clock_res_get.bind(this),
+      clock_time_get: this.wasix_clock_time_get.bind(this),
 
       // File descriptors
       fd_advise: enosys,
@@ -209,7 +272,7 @@ export class WASIX {
       proc_parent: enosys,
 
       // Random
-      random_get: enosys,
+      random_get: this.wasix_random_get.bind(this),
 
       // Scheduling
       sched_yield: enosys,

--- a/packages/wasi/package.json
+++ b/packages/wasi/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "dev": "vite --port 5173",
     "build:docs": "typedoc --options typedoc.config.cjs",
-    "build:tests": "cd programs && cargo wasi build -r && cd .. && cp programs/target/wasm32-wasi/release/*.wasi.wasm public/bin/tests/",
+    "build:tests": "cd programs && cargo wasi build -r && cd .. && cp programs/target/wasm32-wasi/release/*.wasi.wasm public/bin/tests/ && wat2wasm programs/wasix-clock-random/wasix-clock-random.wat -o public/bin/tests/wasix-clock-random.wasm && wat2wasm programs/wasix-deterministic/wasix-deterministic.wat -o public/bin/tests/wasix-deterministic.wasm",
     "build:vite": "tsc --noEmit && vite build",
     "build": "npm run build:docs && npm run build:vite && rimraf dist/src && mv dist/lib/* dist/ && rmdir dist/lib",
     "test:server": "vite --port 5173",

--- a/packages/wasi/programs/wasix-clock-random/wasix-clock-random.wat
+++ b/packages/wasi/programs/wasix-clock-random/wasix-clock-random.wat
@@ -1,0 +1,130 @@
+;; Hand-rolled WASIX clock + random smoke test.
+;;
+;; Exercises clock_time_get(MONOTONIC) twice — asserts the second reading is
+;; strictly greater than the first (exit code 1 on failure). Then exercises
+;; random_get for 32 bytes — asserts at least one byte is non-zero (exit 2).
+;;
+;; Build: wat2wasm wasix-clock-random.wat -o wasix-clock-random.wasm
+;;
+;; WAT rather than cargo-wasix: cargo-wasix is not available in this repo.
+;; Hand-rolled WAT follows the same pattern as wasix-hello.
+
+(module
+  ;; clock_time_get(clock_id: i32, precision: i64, retptr: i32) -> i32
+  (import "wasix_32v1" "clock_time_get"
+    (func $clock_time_get (param i32 i64 i32) (result i32)))
+  ;; random_get(buf: i32, buf_len: i32) -> i32
+  (import "wasix_32v1" "random_get"
+    (func $random_get (param i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "proc_exit"
+    (func $proc_exit (param i32)))
+
+  (memory (;0;) 1)
+  (export "memory" (memory 0))
+  (export "_start" (func $start))
+
+  ;; Memory layout:
+  ;;   offset  0 –  7 : first  clock result (u64 little-endian)
+  ;;   offset  8 – 15 : second clock result (u64 little-endian)
+  ;;   offset 16 – 47 : 32-byte random buffer
+
+  (func $start
+    (local $t1    i64)
+    (local $t2    i64)
+    (local $i     i32)
+    (local $sum   i32)
+
+    ;; ── first clock_time_get(MONOTONIC=1, precision=0, retptr=0) ─────────
+    i32.const 1
+    i64.const 0
+    i32.const 0
+    call $clock_time_get
+    drop
+
+    ;; Spin ~5 000 000 iterations so wall time advances measurably even in
+    ;; browsers (e.g. WebKit) that clamp performance.now() to 1 ms resolution.
+    i32.const 0
+    local.set $i
+    block $burn_break
+      loop $burn_loop
+        local.get $i
+        i32.const 5000000
+        i32.ge_u
+        br_if $burn_break
+        local.get $i
+        i32.const 1
+        i32.add
+        local.set $i
+        br $burn_loop
+      end
+    end
+
+    ;; ── second clock_time_get(MONOTONIC=1, precision=0, retptr=8) ────────
+    i32.const 1
+    i64.const 0
+    i32.const 8
+    call $clock_time_get
+    drop
+
+    ;; ── assert t2 > t1 (exit 1 on failure) ───────────────────────────────
+    i32.const 0
+    i64.load
+    local.set $t1
+    i32.const 8
+    i64.load
+    local.set $t2
+
+    local.get $t2
+    local.get $t1
+    i64.le_u
+    if
+      i32.const 1
+      call $proc_exit
+      unreachable
+    end
+
+    ;; ── random_get(buf=16, buf_len=32) ───────────────────────────────────
+    i32.const 16
+    i32.const 32
+    call $random_get
+    drop
+
+    ;; ── assert at least one byte non-zero (exit 2 if all zeros) ──────────
+    i32.const 0
+    local.set $sum
+    i32.const 0
+    local.set $i
+    block $check_break
+      loop $check_loop
+        local.get $i
+        i32.const 32
+        i32.ge_u
+        br_if $check_break
+        local.get $sum
+        i32.const 16
+        local.get $i
+        i32.add
+        i32.load8_u
+        i32.or
+        local.set $sum
+        local.get $i
+        i32.const 1
+        i32.add
+        local.set $i
+        br $check_loop
+      end
+    end
+
+    local.get $sum
+    i32.eqz
+    if
+      i32.const 2
+      call $proc_exit
+      unreachable
+    end
+
+    ;; ── success ───────────────────────────────────────────────────────────
+    i32.const 0
+    call $proc_exit
+  )
+)

--- a/packages/wasi/programs/wasix-deterministic/wasix-deterministic.wat
+++ b/packages/wasi/programs/wasix-deterministic/wasix-deterministic.wat
@@ -1,0 +1,71 @@
+;; Hand-rolled WASIX determinism smoke test.
+;;
+;; Calls random_get for 8 bytes and clock_time_get(REALTIME) for 8 bytes,
+;; then writes all 16 bytes to stdout via fd_write. Playwright runs this
+;; binary twice with identical FixedClockProvider(0n) + SeededRandomProvider(42)
+;; and asserts that the stdout bytes are equal across both runs.
+;;
+;; Build: wat2wasm wasix-deterministic.wat -o wasix-deterministic.wasm
+;;
+;; WAT rather than cargo-wasix: cargo-wasix is not available in this repo.
+;; Hand-rolled WAT follows the same pattern as wasix-hello.
+
+(module
+  ;; clock_time_get(clock_id: i32, precision: i64, retptr: i32) -> i32
+  (import "wasix_32v1" "clock_time_get"
+    (func $clock_time_get (param i32 i64 i32) (result i32)))
+  ;; random_get(buf: i32, buf_len: i32) -> i32
+  (import "wasix_32v1" "random_get"
+    (func $random_get (param i32 i32) (result i32)))
+  ;; fd_write(fd: i32, iovs: i32, iovs_len: i32, nwritten: i32) -> i32
+  (import "wasi_snapshot_preview1" "fd_write"
+    (func $fd_write (param i32 i32 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "proc_exit"
+    (func $proc_exit (param i32)))
+
+  (memory (;0;) 1)
+  (export "memory" (memory 0))
+  (export "_start" (func $start))
+
+  ;; Memory layout:
+  ;;   offset  0 –  7 : random_get result (8 bytes)
+  ;;   offset  8 – 15 : clock_time_get result (u64 little-endian)
+  ;;   offset 16 – 19 : iov[0].buf  (u32) — pointer to output data
+  ;;   offset 20 – 23 : iov[0].len  (u32) — 16 bytes total
+  ;;   offset 24 – 27 : nwritten    (u32)
+
+  (func $start
+    ;; random_get(buf=0, buf_len=8) → 8 bytes at offset 0
+    i32.const 0
+    i32.const 8
+    call $random_get
+    drop
+
+    ;; clock_time_get(REALTIME=0, precision=0, retptr=8) → 8 bytes at offset 8
+    i32.const 0
+    i64.const 0
+    i32.const 8
+    call $clock_time_get
+    drop
+
+    ;; Set up iov: buf_ptr=0, buf_len=16
+    i32.const 16
+    i32.const 0
+    i32.store
+    i32.const 20
+    i32.const 16
+    i32.store
+
+    ;; fd_write(fd=1, iovs=16, iovs_len=1, nwritten=24)
+    i32.const 1
+    i32.const 16
+    i32.const 1
+    i32.const 24
+    call $fd_write
+    drop
+
+    ;; Exit 0
+    i32.const 0
+    call $proc_exit
+  )
+)

--- a/packages/wasi/programs/wasix-deterministic/wasix-deterministic.wat
+++ b/packages/wasi/programs/wasix-deterministic/wasix-deterministic.wat
@@ -1,9 +1,11 @@
 ;; Hand-rolled WASIX determinism smoke test.
 ;;
 ;; Calls random_get for 8 bytes and clock_time_get(REALTIME) for 8 bytes,
-;; then writes all 16 bytes to stdout via fd_write. Playwright runs this
-;; binary twice with identical FixedClockProvider(0n) + SeededRandomProvider(42)
-;; and asserts that the stdout bytes are equal across both runs.
+;; then writes all 16 bytes to stdout as a 32-character lowercase hex string
+;; via fd_write. Hex-encoding (rather than raw bytes) keeps the byte sequence
+;; intact through TextDecoder so the spec can pin a golden string.
+;; Playwright runs this binary under FixedClockProvider(0n) +
+;; SeededRandomProvider(42) and asserts the exact hex output.
 ;;
 ;; Build: wat2wasm wasix-deterministic.wat -o wasix-deterministic.wasm
 ;;
@@ -29,12 +31,21 @@
 
   ;; Memory layout:
   ;;   offset  0 –  7 : random_get result (8 bytes)
-  ;;   offset  8 – 15 : clock_time_get result (u64 little-endian)
-  ;;   offset 16 – 19 : iov[0].buf  (u32) — pointer to output data
-  ;;   offset 20 – 23 : iov[0].len  (u32) — 16 bytes total
-  ;;   offset 24 – 27 : nwritten    (u32)
+  ;;   offset  8 – 15 : clock_time_get result (u64 little-endian, 8 bytes)
+  ;;   offset 16 – 47 : hex-encoded output (32 ASCII chars)
+  ;;   offset 48 – 51 : iov[0].buf  (u32) — pointer to hex output (= 16)
+  ;;   offset 52 – 55 : iov[0].len  (u32) — 32 bytes
+  ;;   offset 56 – 59 : nwritten    (u32)
+  ;;   offset 64 – 79 : "0123456789abcdef" hex digit table
+
+  (data (i32.const 64) "0123456789abcdef")
 
   (func $start
+    (local $i i32)        ;; loop index over 16 input bytes
+    (local $b i32)        ;; current byte
+    (local $hi i32)       ;; high nibble
+    (local $lo i32)       ;; low nibble
+
     ;; random_get(buf=0, buf_len=8) → 8 bytes at offset 0
     i32.const 0
     i32.const 8
@@ -48,19 +59,82 @@
     call $clock_time_get
     drop
 
-    ;; Set up iov: buf_ptr=0, buf_len=16
-    i32.const 16
+    ;; Hex-encode 16 input bytes (offset 0..15) into 32 ASCII chars (offset 16..47).
+    ;; for (i = 0; i < 16; i++) {
+    ;;   b  = mem[i];
+    ;;   hi = b >> 4;
+    ;;   lo = b & 0xf;
+    ;;   mem[16 + i*2]     = hex_table[hi];
+    ;;   mem[16 + i*2 + 1] = hex_table[lo];
+    ;; }
     i32.const 0
-    i32.store
-    i32.const 20
+    local.set $i
+    (block $break
+      (loop $loop
+        local.get $i
+        i32.const 16
+        i32.ge_u
+        br_if $break
+
+        local.get $i
+        i32.load8_u
+        local.set $b
+
+        local.get $b
+        i32.const 4
+        i32.shr_u
+        local.set $hi
+
+        local.get $b
+        i32.const 0xf
+        i32.and
+        local.set $lo
+
+        ;; mem[16 + i*2] = mem[64 + hi]
+        i32.const 16
+        local.get $i
+        i32.const 1
+        i32.shl
+        i32.add
+        local.get $hi
+        i32.const 64
+        i32.add
+        i32.load8_u
+        i32.store8
+
+        ;; mem[16 + i*2 + 1] = mem[64 + lo]
+        i32.const 17
+        local.get $i
+        i32.const 1
+        i32.shl
+        i32.add
+        local.get $lo
+        i32.const 64
+        i32.add
+        i32.load8_u
+        i32.store8
+
+        local.get $i
+        i32.const 1
+        i32.add
+        local.set $i
+        br $loop
+      )
+    )
+
+    ;; Set up iov: buf_ptr=16, buf_len=32
+    i32.const 48
     i32.const 16
+    i32.store
+    i32.const 52
+    i32.const 32
     i32.store
 
-    ;; fd_write(fd=1, iovs=16, iovs_len=1, nwritten=24)
+    ;; fd_write(fd=1, iovs=48, iovs_len=1, nwritten=56)
     i32.const 1
-    i32.const 16
+    i32.const 48
     i32.const 1
-    i32.const 24
+    i32.const 56
     call $fd_write
     drop
 

--- a/packages/wasi/src/main.ts
+++ b/packages/wasi/src/main.ts
@@ -1,10 +1,23 @@
 import "./style.css";
-import { WASI, WASIContext, WASIX, WASIXContext } from "../lib/main.js";
+import {
+  WASI,
+  WASIContext,
+  WASIX,
+  WASIXContext,
+  SystemClockProvider,
+  SystemRandomProvider,
+  FixedClockProvider,
+  SeededRandomProvider,
+} from "../lib/main.js";
 
 (window as any)["WASI"] = WASI;
 (window as any)["WASIContext"] = WASIContext;
 (window as any)["WASIX"] = WASIX;
 (window as any)["WASIXContext"] = WASIXContext;
+(window as any)["SystemClockProvider"] = SystemClockProvider;
+(window as any)["SystemRandomProvider"] = SystemRandomProvider;
+(window as any)["FixedClockProvider"] = FixedClockProvider;
+(window as any)["SeededRandomProvider"] = SeededRandomProvider;
 
 const programSelect = document.getElementById("program")! as HTMLSelectElement;
 const argsInput = document.getElementById("args")! as HTMLInputElement;

--- a/packages/wasi/tests/wasix-clock-random.spec.ts
+++ b/packages/wasi/tests/wasix-clock-random.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from "@playwright/test";
+
+import type {
+  WASIX,
+  WASIXContext,
+  FixedClockProvider,
+  SeededRandomProvider,
+} from "../lib/main";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("http://localhost:5173");
+  await page.waitForLoadState("domcontentloaded");
+});
+
+test("wasix-clock-random: monotonic delta > 0 and non-zero random bytes", async ({
+  page,
+}) => {
+  const result = await page.evaluate(async function () {
+    while ((window as any)["WASIX"] === undefined) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+
+    const W: typeof WASIX = (window as any)["WASIX"];
+    const WC: typeof WASIXContext = (window as any)["WASIXContext"];
+
+    const wasiResult = await W.start(
+      fetch("/bin/tests/wasix-clock-random.wasm"),
+      new WC({
+        args: [],
+        stdout: () => {},
+        stderr: () => {},
+        stdin: () => null,
+        fs: {},
+      }),
+    );
+
+    return { exitCode: wasiResult.exitCode };
+  });
+
+  expect(result.exitCode).toBe(0);
+});
+
+test("wasix-deterministic: byte-identical stdout across two runs with fixed providers", async ({
+  page,
+}) => {
+  const result = await page.evaluate(async function () {
+    while ((window as any)["WASIX"] === undefined) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+
+    const W: typeof WASIX = (window as any)["WASIX"];
+    const WC: typeof WASIXContext = (window as any)["WASIXContext"];
+    const FC: typeof FixedClockProvider = (window as any)["FixedClockProvider"];
+    const SR: typeof SeededRandomProvider = (window as any)[
+      "SeededRandomProvider"
+    ];
+
+    const run = async () => {
+      const chunks: string[] = [];
+      const wasiResult = await W.start(
+        fetch("/bin/tests/wasix-deterministic.wasm"),
+        new WC({
+          args: [],
+          clock: new FC(BigInt(0), BigInt(0)),
+          random: new SR(42),
+          stdout: (out: string) => {
+            chunks.push(out);
+          },
+          stderr: () => {},
+          stdin: () => null,
+          fs: {},
+        }),
+      );
+      return { exitCode: wasiResult.exitCode, stdout: chunks.join("") };
+    };
+
+    const run1 = await run();
+    const run2 = await run();
+
+    return {
+      exitCode1: run1.exitCode,
+      exitCode2: run2.exitCode,
+      stdoutMatch: run1.stdout === run2.stdout,
+      stdoutLen: run1.stdout.length,
+    };
+  });
+
+  expect(result.exitCode1).toBe(0);
+  expect(result.exitCode2).toBe(0);
+  expect(result.stdoutMatch).toBe(true);
+  // 16 bytes written; TextDecoder may merge into fewer chars but length > 0
+  expect(result.stdoutLen).toBeGreaterThan(0);
+});

--- a/packages/wasi/tests/wasix-clock-random.spec.ts
+++ b/packages/wasi/tests/wasix-clock-random.spec.ts
@@ -80,14 +80,18 @@ test("wasix-deterministic: byte-identical stdout across two runs with fixed prov
     return {
       exitCode1: run1.exitCode,
       exitCode2: run2.exitCode,
-      stdoutMatch: run1.stdout === run2.stdout,
-      stdoutLen: run1.stdout.length,
+      stdout1: run1.stdout,
+      stdout2: run2.stdout,
     };
   });
 
+  // Golden output: 8 SFC32(seed=42) bytes hex-encoded, then 8 zero bytes from
+  // FixedClockProvider(0n, 0n). Pinning the exact bytes catches algorithm drift
+  // that mere reproducibility-across-runs would not.
+  const expectedStdout = "b4b5424d031fbb710000000000000000";
+
   expect(result.exitCode1).toBe(0);
   expect(result.exitCode2).toBe(0);
-  expect(result.stdoutMatch).toBe(true);
-  // 16 bytes written; TextDecoder may merge into fewer chars but length > 0
-  expect(result.stdoutLen).toBeGreaterThan(0);
+  expect(result.stdout1).toBe(expectedStdout);
+  expect(result.stdout2).toBe(expectedStdout);
 });


### PR DESCRIPTION
## Summary

Wires sync clock + random providers into WASIX per `WASIX-PLAN.md`:

- **`WASIXError`** (`wasix-32v1.ts`) — providers throw it; the syscall layer translates to `Result.*`. Anything else thrown becomes `EIO` via the existing `debug` hook.
- **Four providers** — `SystemClockProvider` (`performance.now()` for `MONOTONIC`, `Date.now()` for the rest), `SystemRandomProvider` (`crypto.getRandomValues`), `FixedClockProvider(epochNs, tick)` (per-call advance, default `0n` = frozen), `SeededRandomProvider(seed)` (SFC32 with 15 warm-up rounds — integer-only, engine-identical).
- **Three syscalls wired** — `wasix_32v1.clock_time_get`, `clock_res_get`, `random_get` call through to the provider; lazy-initialised system defaults when no provider is supplied. Unknown `ClockId` returns `EINVAL`, not `EIO`.
- **`ClockId` enum** — `REALTIME`, `MONOTONIC`, `PROCESS_CPUTIME`, `THREAD_CPUTIME`.
- **Public surface** — all four providers re-exported from `lib/main.ts` and attached to `window` for Playwright.
- **Smoke + determinism specs** — `wasix-clock-random.wat` asserts MONOTONIC delta > 0 and non-zero random bytes; `wasix-deterministic.wat` hex-encodes 8 SFC32(seed=42) bytes + 8 bytes from `FixedClock(0n,0n)` to stdout. Spec asserts the literal golden `b4b5424d031fbb710000000000000000` across two runs — pins the algorithm rather than just round-trip equality.
- **CI** — `apt-get install wabt` so `wat2wasm` is available in the PR test workflow.

## Deviation note — hand-rolled WAT, not `cargo wasix`

Same substitution as Slice 1: cargo-wasix isn't installable in this repo's toolchain, so the smoke binaries are written in WAT and built via `wat2wasm`. The slice spec called out the `cargo wasix` path as a preference rather than a requirement.

## Test plan

- [x] chromium / firefox / webkit green on the new `wasix-clock-random.spec.ts` (CI run at tip)
- [x] No regressions in existing `args` / `stdio` / `wasix-smoke` specs
- [x] `tsc --noEmit` clean
- [x] Determinism test pins exact bytes — algorithm drift in either provider would now flip the assertion

## Follow-ups (already stacked on this branch)

- Slice 3 — filesystem provider + wasmer test harness
- Slice 4 — WASIXWorkerHost + Atomics bridge (carries COOP/COEP)