### PR TITLE
WASIX Slice 3.5: Module-instantiation surface (env imports + v2 stubs + COOP/COEP)

### DIFF
--- a/packages/wasi/WASIX-PLAN.md
+++ b/packages/wasi/WASIX-PLAN.md
@@ -1,6 +1,6 @@
 # WASIX support — technical design
 
-*Status: design phase. Describes the target architecture; revise as decisions land.*
+_Status: design phase. Describes the target architecture; revise as decisions land._
 
 ## Goal
 
@@ -41,7 +41,7 @@ Every WASIX syscall has a provider slot. Unwired slots return `ENOSYS`.
   the path to lifting this.
 - `proc_exec` and `proc_spawn` are **not** in this category — they start a
   fresh instance, which a provider can do. Expected to pass.
-- Real socket / process / thread implementations baked into the runtime *or*
+- Real socket / process / thread implementations baked into the runtime _or_
   shipped as Runno providers. Runno is a sandbox; its providers are
   simulations. A host that wants real-world semantics wires its own
   providers — Runno does not ship them.
@@ -59,24 +59,34 @@ export { WASIX, WASIXContext, WASIXWorkerHost } from "./wasix/...";
 
 // Raw provider interfaces — always synchronous, consumed by `WASIX`
 export type {
-  ClockProvider, RandomProvider,
-  TTYProvider, ThreadsProvider, FutexProvider,
-  SignalsProvider, SocketsProvider, ProcProvider,
+  ClockProvider,
+  RandomProvider,
+  TTYProvider,
+  ThreadsProvider,
+  FutexProvider,
+  SignalsProvider,
+  SocketsProvider,
+  ProcProvider,
 } from "./wasix/providers.js";
 
 // Async-capable variants — accepted only by WASIXWorkerHost
 export type {
-  AsyncClockProvider, AsyncRandomProvider,
-  AsyncTTYProvider, AsyncThreadsProvider, AsyncFutexProvider,
-  AsyncSignalsProvider, AsyncSocketsProvider, AsyncProcProvider,
+  AsyncClockProvider,
+  AsyncRandomProvider,
+  AsyncTTYProvider,
+  AsyncThreadsProvider,
+  AsyncFutexProvider,
+  AsyncSignalsProvider,
+  AsyncSocketsProvider,
+  AsyncProcProvider,
   AsyncCapable,
 } from "./wasix/providers/async.js";
 
 // Ergonomic providers — concrete classes hosts can drop in
 export {
-  HTTPProvider,        // AsyncSocketsProvider (Fetch-style) — worker-only
-  FileSystemProvider,  // wraps WASIDrive; sync + async variants
-  ConsoleTTYProvider,  // TTYProvider (sync)
+  HTTPProvider, // AsyncSocketsProvider (Fetch-style) — worker-only
+  FileSystemProvider, // wraps WASIDrive; sync + async variants
+  ConsoleTTYProvider, // TTYProvider (sync)
 } from "./wasix/providers/ergonomic.js";
 ```
 
@@ -155,14 +165,14 @@ type WASIXContextOptions = {
 
   // Providers — all sync. Async variants are configured via
   // WASIXWorkerHostOptions; see "Async-capable providers" below.
-  clock?:   ClockProvider;    // clock_time_get, clock_res_get
-  random?:  RandomProvider;   // random_get
-  tty?:     TTYProvider;      // tty_get, tty_set
-  threads?: ThreadsProvider;  // thread_spawn/join/exit/sleep/id/parallelism/signal
-  futex?:   FutexProvider;    // futex_wait, futex_wake(_all)
-  signals?: SignalsProvider;  // signal_register, proc_raise_interval
-  sockets?: SocketsProvider;  // WASIX socket surface (TCP/UDP/resolve)
-  proc?:    ProcProvider;     // proc_id, proc_fork/spawn/exec/join, proc_parent
+  clock?: ClockProvider; // clock_time_get, clock_res_get
+  random?: RandomProvider; // random_get
+  tty?: TTYProvider; // tty_get, tty_set
+  threads?: ThreadsProvider; // thread_spawn/join/exit/sleep/id/parallelism/signal
+  futex?: FutexProvider; // futex_wait, futex_wake(_all)
+  signals?: SignalsProvider; // signal_register, proc_raise_interval
+  sockets?: SocketsProvider; // WASIX socket surface (TCP/UDP/resolve)
+  proc?: ProcProvider; // proc_id, proc_fork/spawn/exec/join, proc_parent
 };
 ```
 
@@ -193,7 +203,7 @@ Raw interface shapes (final forms pinned during implementation):
 
 ```ts
 interface ClockProvider {
-  now(id: ClockId): bigint;                  // nanoseconds
+  now(id: ClockId): bigint; // nanoseconds
   resolution(id: ClockId): bigint;
 }
 
@@ -202,8 +212,8 @@ interface RandomProvider {
 }
 
 interface ThreadsProvider {
-  spawn(startArg: number): number;    // tid
-  join(tid: number): number;          // exit code
+  spawn(startArg: number): number; // tid
+  join(tid: number): number; // exit code
   exit(code: number): void;
   sleep(durationNs: bigint): void;
   id(): number;
@@ -249,7 +259,7 @@ interface SignalsProvider {
 }
 
 interface TTYProvider {
-  get(): TTYState;       // cols, rows, pixel size, echo, line, raw, …
+  get(): TTYState; // cols, rows, pixel size, echo, line, raw, …
   set(state: TTYState): Result;
 }
 ```
@@ -266,7 +276,7 @@ type AsyncCapable<T> = {
     : T[K];
 };
 
-type AsyncClockProvider   = AsyncCapable<ClockProvider>;
+type AsyncClockProvider = AsyncCapable<ClockProvider>;
 type AsyncSocketsProvider = AsyncCapable<SocketsProvider>;
 // …one per raw provider
 ```
@@ -298,8 +308,8 @@ bundled clock and filesystem is a normal configuration.
   about HTTP, not raw TCP/UDP. `HTTPProvider` exposes two handlers:
   ```ts
   new HTTPProvider({
-    outgoing: (req: Request) => Response | Promise<Response>,   // guest-initiated
-    incoming: (port: number) => ReadableStream<Request>,         // guest-bound service
+    outgoing: (req: Request) => Response | Promise<Response>, // guest-initiated
+    incoming: (port: number) => ReadableStream<Request>, // guest-bound service
   });
   ```
   Internally it translates socket-level calls (`connect`, `send`, `recv`)
@@ -359,17 +369,19 @@ Promise. The types enforce the split — an async-capable provider passed to
 ## Thread / memory model
 
 Threaded WASIX binaries expect:
+
 - A `wasi_thread_start(tid: i32, startArg: i32) -> ()` export on the module.
 - The module imports its memory (`env.memory`) rather than exporting it, and
   that memory is declared `shared: true`.
 
 The runtime's responsibility:
+
 - Construct (or accept from the host) a
   `WebAssembly.Memory({ initial, maximum, shared: true })`.
 - Instantiate the main module against that memory.
 - On `thread_spawn(startArg)`, call `ThreadsProvider.spawn(startArg)` for a TID.
 
-The *semantics* of running the new thread are the provider's problem:
+The _semantics_ of running the new thread are the provider's problem:
 
 - A real-worker provider instantiates a new worker, loads the same WASM module
   against the same shared `Memory`, and calls `wasi_thread_start(tid, startArg)`.
@@ -398,6 +410,21 @@ A host can override auto-detection by passing `WASIXContextOptions.memory`
 threaded configuration). If supplied, it must satisfy whichever mode the
 module expects.
 
+### Sequencing
+
+The auto-detect path lands ahead of the threads / futex provider work
+because every wasix-libc binary imports `env.memory` (declared `shared`)
+regardless of whether the test exercises threads. wasix-libc is built with
+`-pthread -mthread-model posix -matomics -mbulk-memory` for the whole
+sysroot, so a strictly single-threaded filesystem test still rejects at
+`WebAssembly.instantiate` until the runtime supplies a matching shared
+`WebAssembly.Memory`. Wiring the import surface is therefore a prerequisite
+for any wasmer-suite coverage — including the FS tests served by Slice 3 —
+and ships in a small carve-out (Slice 3.5) that does not introduce the
+threads provider, the futex provider, or the worker-host bridge. Those
+remain in their own slices and consume the same auto-detected memory
+when they land.
+
 ## Determinism
 
 With `clock` and `random` as providers, a host can pin either or both for
@@ -405,8 +432,8 @@ reproducibility:
 
 ```ts
 const wasix = new WASIX({
-  clock:  new FixedClockProvider(0n),     // epoch 0, monotonic 0
-  random: new SeededRandomProvider(42),   // seeded PRNG
+  clock: new FixedClockProvider(0n), // epoch 0, monotonic 0
+  random: new SeededRandomProvider(42), // seeded PRNG
   // …
 });
 ```
@@ -449,7 +476,7 @@ integration suite runner configures a `WASIX` instance from this set; a unit
 test can swap in a `FixedClockProvider`, a `SeededRandomProvider`, or its own
 fakes.
 
-This is the design point: *simulations are enough to pass the suite.* The
+This is the design point: _simulations are enough to pass the suite._ The
 tests exercise API shape and errno behaviour, not real-world networking or
 real OS process semantics. A host that needs real behaviour plugs in its own
 providers (e.g. a `node-sockets.ts` backed by `node:net`) — but Runno doesn't
@@ -502,7 +529,7 @@ There is no API for it, public or private.
 
 Entering a WASM instance from JS means calling an export from its start.
 There is no "resume at frame N, instruction M." So a provider can clone
-memory but cannot tell the child instance *where to begin*.
+memory but cannot tell the child instance _where to begin_.
 
 The same limitation hits two related syscalls:
 
@@ -518,7 +545,7 @@ In all three, the root cause is identical: **WASM execution state is not
 reifiable from JS**.
 
 Both workarounds described in [Future: Asyncify opt-in](#future-asyncify-opt-in)
-operate below the provider layer. Asyncify moves the stack *into* guest
+operate below the provider layer. Asyncify moves the stack _into_ guest
 memory where JS can see it; JSPI adds a first-class pause/resume primitive
 at the engine. Neither is something a provider can do at call time — which
 is why v1 ships with these tests skipped rather than working around them.

--- a/packages/wasi/lib/wasi/wasi-drive.ts
+++ b/packages/wasi/lib/wasi/wasi-drive.ts
@@ -20,12 +20,24 @@ export type DriveStat = {
   type: FileType;
 };
 
+export type WASIDrivePreopen = {
+  /** File-descriptor number to bind this preopen to. Defaults to the next free fd starting at 4. */
+  fd?: FileDescriptor;
+  /** Drive-internal prefix (always rooted, trailing slash) used when resolving paths through this fd. */
+  prefix: string;
+};
+
+export type WASIDriveOptions = {
+  /** Additional preopens beyond the implicit fd 3 = "/" root. */
+  preopens?: WASIDrivePreopen[];
+};
+
 export class WASIDrive {
   fs: WASIFS;
   nextFD: FileDescriptor = 10;
   openMap: Map<FileDescriptor, OpenFile | OpenDirectory> = new Map();
 
-  constructor(fs: WASIFS) {
+  constructor(fs: WASIFS, options?: WASIDriveOptions) {
     this.fs = { ...fs };
 
     // Preopens are discovered by the binary using `fd_prestat_get` and then
@@ -35,6 +47,16 @@ export class WASIDrive {
     //   1. how to access preopens - https://github.com/WebAssembly/WASI/issues/323
     //   2. how preopens work - https://github.com/WebAssembly/WASI/issues/352
     this.openMap.set(3, new OpenDirectory(this.fs, "/"));
+
+    // Extra preopens (WASIX runtimes pass these to expose mounts beyond the
+    // implicit root, e.g. "/home" alongside ".").
+    if (options?.preopens) {
+      let nextPreopenFd = 4;
+      for (const preopen of options.preopens) {
+        const fd = preopen.fd ?? nextPreopenFd++;
+        this.openMap.set(fd, new OpenDirectory(this.fs, preopen.prefix));
+      }
+    }
   }
 
   //
@@ -43,7 +65,7 @@ export class WASIDrive {
   private openFile(
     fileData: WASIFile,
     truncateFile: boolean,
-    fdflags: number
+    fdflags: number,
   ): DriveResult<FileDescriptor> {
     const file = new OpenFile(fileData, fdflags);
     if (truncateFile) {
@@ -78,7 +100,7 @@ export class WASIDrive {
     fdDir: FileDescriptor,
     path: WASIPath,
     oflags: number,
-    fdflags: number
+    fdflags: number,
   ): DriveResult<FileDescriptor> {
     const createFileIfNone: boolean = !!(oflags & OpenFlags.CREAT);
     const failIfNotDir: boolean = !!(oflags & OpenFlags.DIRECTORY);
@@ -103,11 +125,13 @@ export class WASIDrive {
       return this.openFile(openDir.get(path)!, truncateFile, fdflags);
     } else if (this.hasDir(openDir, path)) {
       if (path === ".") {
-        return this.openDir(this.fs, "/");
+        return this.openDir(this.fs, openDir.prefix);
       }
 
-      const prefix = `/${path}/`;
-      // This is a directory
+      // Compose the new prefix from the parent preopen's prefix so a
+      // sub-directory open under a non-root preopen (e.g. fd 4 at
+      // "/home/") resolves to "/home/<path>/" rather than "/<path>/".
+      const prefix = `${openDir.prefix}${path}/`;
       const dir = Object.entries(this.fs).filter(([s]) => s.startsWith(prefix));
       return this.openDir(Object.fromEntries(dir), prefix);
     } else {
@@ -155,7 +179,7 @@ export class WASIDrive {
   pread(
     fd: FileDescriptor,
     bytes: number,
-    offset: number
+    offset: number,
   ): DriveResult<Uint8Array> {
     const file = this.openMap.get(fd);
     if (!file || file instanceof OpenDirectory) {
@@ -199,7 +223,7 @@ export class WASIDrive {
   seek(
     fd: FileDescriptor,
     offset: bigint,
-    whence: Whence
+    whence: Whence,
   ): DriveResult<bigint> {
     const file = this.openMap.get(fd);
     if (!file || file instanceof OpenDirectory) {
@@ -259,7 +283,7 @@ export class WASIDrive {
     oldFdDir: FileDescriptor,
     oldPath: string,
     newFdDir: FileDescriptor,
-    newPath: string
+    newPath: string,
   ): Result {
     const oldDir = this.openMap.get(oldFdDir);
     const newDir = this.openMap.get(newFdDir);
@@ -324,12 +348,17 @@ export class WASIDrive {
       return [Result.SUCCESS, stat];
     } else if (this.hasDir(dir, path)) {
       if (path === ".") {
-        return [Result.SUCCESS, new OpenDirectory(this.fs, "/").stat()];
+        return [Result.SUCCESS, new OpenDirectory(this.fs, dir.prefix).stat()];
       }
 
-      const prefix = `/${path}/`;
-      const dir = Object.entries(this.fs).filter(([s]) => s.startsWith(prefix));
-      const stat = new OpenDirectory(Object.fromEntries(dir), prefix).stat();
+      // See comment in `open` — the new prefix must include the parent
+      // preopen's prefix so multi-preopen layouts (e.g. fd 4 = "/home/")
+      // resolve sub-directories under the right subtree.
+      const prefix = `${dir.prefix}${path}/`;
+      const subset = Object.entries(this.fs).filter(([s]) =>
+        s.startsWith(prefix),
+      );
+      const stat = new OpenDirectory(Object.fromEntries(subset), prefix).stat();
       return [Result.SUCCESS, stat];
     } else {
       return [Result.ENOTCAPABLE];
@@ -395,7 +424,7 @@ export class WASIDrive {
   pathSetModificationTime(
     fdDir: FileDescriptor,
     path: string,
-    date: Date
+    date: Date,
   ): Result {
     const dir = this.openMap.get(fdDir);
     if (!(dir instanceof OpenDirectory)) {
@@ -525,7 +554,7 @@ class OpenFile {
     } else {
       const newSize = Math.max(
         this.offset + data.byteLength,
-        this.buffer.byteLength
+        this.buffer.byteLength,
       );
       this.resize(newSize);
       this.buffer.set(data, this.offset);
@@ -548,7 +577,7 @@ class OpenFile {
     } else {
       const newSize = Math.max(
         offset + data.byteLength,
-        this.buffer.byteLength
+        this.buffer.byteLength,
       );
       this.resize(newSize);
       this.buffer.set(data, offset);
@@ -638,7 +667,7 @@ class OpenFile {
 
     if (this.buffer.buffer.byteLength === 0) {
       underBuffer = new ArrayBuffer(
-        requiredBytes < 1024 ? 1024 : requiredBytes * 2
+        requiredBytes < 1024 ? 1024 : requiredBytes * 2,
       );
     } else if (requiredBytes > this.buffer.buffer.byteLength * 2) {
       underBuffer = new ArrayBuffer(requiredBytes * 2);

--- a/packages/wasi/lib/wasi/wasi-drive.ts
+++ b/packages/wasi/lib/wasi/wasi-drive.ts
@@ -36,6 +36,14 @@ export class WASIDrive {
   fs: WASIFS;
   nextFD: FileDescriptor = 10;
   openMap: Map<FileDescriptor, OpenFile | OpenDirectory> = new Map();
+  /**
+   * Set of fds bound to preopens. Their entries in `openMap` survive
+   * user-initiated `close()` calls because wasix-libc's preopen cache
+   * keeps using them to resolve cwd-relative paths even after the guest
+   * believes the fd is closed (matches wasmer runtime behaviour — the
+   * `closing-pre-opened-dirs` test relies on it).
+   */
+  private preopens: Set<FileDescriptor> = new Set();
 
   constructor(fs: WASIFS, options?: WASIDriveOptions) {
     this.fs = { ...fs };
@@ -47,6 +55,7 @@ export class WASIDrive {
     //   1. how to access preopens - https://github.com/WebAssembly/WASI/issues/323
     //   2. how preopens work - https://github.com/WebAssembly/WASI/issues/352
     this.openMap.set(3, new OpenDirectory(this.fs, "/"));
+    this.preopens.add(3);
 
     // Extra preopens (WASIX runtimes pass these to expose mounts beyond the
     // implicit root, e.g. "/home" alongside ".").
@@ -55,6 +64,7 @@ export class WASIDrive {
       for (const preopen of options.preopens) {
         const fd = preopen.fd ?? nextPreopenFd++;
         this.openMap.set(fd, new OpenDirectory(this.fs, preopen.prefix));
+        this.preopens.add(fd);
       }
     }
   }
@@ -93,12 +103,40 @@ export class WASIDrive {
     return dir.containsDirectory(path);
   }
 
+  /**
+   * If `path` has a parent component, validate that the parent
+   * resolves to an existing directory. POSIX behaviour:
+   *   - parent doesn't exist → ENOENT
+   *   - parent is a regular file → ENOTDIR
+   *
+   * Returns `null` when validation passes (or there is no parent
+   * component, i.e. the operation targets a single segment under the
+   * directory). Both `open(O_CREAT)` and `mkdir` need this guard so the
+   * flat-path map can't be tricked into planting entries under a leaf
+   * file or a non-existent prefix.
+   */
+  private validateParent(
+    dir: OpenDirectory,
+    path: string,
+  ): Result.ENOTDIR | Result.ENOENT | null {
+    const lastSlash = path.lastIndexOf("/");
+    if (lastSlash <= 0) return null;
+    const parent = path.slice(0, lastSlash);
+    if (dir.containsFile(parent)) {
+      return Result.ENOTDIR;
+    }
+    if (!dir.containsDirectory(parent)) {
+      return Result.ENOENT;
+    }
+    return null;
+  }
+
   //
   // Public Interface
   //
   open(
     fdDir: FileDescriptor,
-    path: WASIPath,
+    rawPath: WASIPath,
     oflags: number,
     fdflags: number,
   ): DriveResult<FileDescriptor> {
@@ -111,6 +149,20 @@ export class WASIDrive {
     if (!(openDir instanceof OpenDirectory)) {
       // Must be relative to a directory
       return [Result.EBADF];
+    }
+
+    const path = normalizeRelative(rawPath);
+    if (path === null) {
+      // Tried to escape past the directory root; the flat-path drive
+      // has no notion of a parent above the preopen.
+      return [Result.ENOTCAPABLE];
+    }
+
+    // POSIX: if a path component above the leaf is a regular file or
+    // doesn't exist, fail before touching the flat path map.
+    const parentErr = this.validateParent(openDir, path);
+    if (parentErr !== null) {
+      return [parentErr];
     }
 
     if (openDir.containsFile(path)) {
@@ -149,6 +201,14 @@ export class WASIDrive {
         };
         return this.openFile(this.fs[fullPath], truncateFile, fdflags);
       }
+      // ENOTCAPABLE is the preview1 vocabulary for "drive can't
+      // satisfy this open"; it covers both "path missing" and
+      // "capability not granted" because the flat-path map can't
+      // distinguish them. The WASIX provider translates this to
+      // ENOENT for POSIX-shaped binaries that key on `errno ==
+      // ENOENT`. Preview1 callers see the original code so the WASI
+      // test suite (which asserts ENOTCAPABLE explicitly) keeps
+      // passing.
       return [Result.ENOTCAPABLE];
     }
   }
@@ -161,6 +221,13 @@ export class WASIDrive {
     const file = this.openMap.get(fd);
     if (file instanceof OpenFile) {
       file.sync();
+    }
+
+    // Preopen fds report success but stay in the map. wasix-libc's
+    // resolver keeps them in its own cache and re-uses them to translate
+    // cwd-relative paths after the guest "closes" them.
+    if (this.preopens.has(fd)) {
+      return Result.SUCCESS;
     }
 
     this.openMap.delete(fd);
@@ -256,11 +323,16 @@ export class WASIDrive {
     return Result.SUCCESS;
   }
 
-  unlink(fdDir: FileDescriptor, path: string): Result {
+  unlink(fdDir: FileDescriptor, rawPath: string): Result {
     const openDir = this.openMap.get(fdDir);
     if (!(openDir instanceof OpenDirectory)) {
       // Must be relative to a directory
       return Result.EBADF;
+    }
+
+    const path = normalizeRelative(rawPath);
+    if (path === null || path === ".") {
+      return Result.ENOENT;
     }
 
     if (!openDir.contains(path)) {
@@ -281,9 +353,9 @@ export class WASIDrive {
 
   rename(
     oldFdDir: FileDescriptor,
-    oldPath: string,
+    rawOldPath: string,
     newFdDir: FileDescriptor,
-    newPath: string,
+    rawNewPath: string,
   ): Result {
     const oldDir = this.openMap.get(oldFdDir);
     const newDir = this.openMap.get(newFdDir);
@@ -293,6 +365,17 @@ export class WASIDrive {
     ) {
       // Must be relative to a directory
       return Result.EBADF;
+    }
+
+    const oldPath = normalizeRelative(rawOldPath);
+    const newPath = normalizeRelative(rawNewPath);
+    if (
+      oldPath === null ||
+      newPath === null ||
+      oldPath === "." ||
+      newPath === "."
+    ) {
+      return Result.ENOENT;
     }
 
     if (!oldDir.contains(oldPath)) {
@@ -336,10 +419,15 @@ export class WASIDrive {
     return [Result.SUCCESS, file.stat()];
   }
 
-  pathStat(fdDir: FileDescriptor, path: string): DriveResult<DriveStat> {
+  pathStat(fdDir: FileDescriptor, rawPath: string): DriveResult<DriveStat> {
     const dir = this.openMap.get(fdDir);
     if (!(dir instanceof OpenDirectory)) {
       return [Result.EBADF];
+    }
+
+    const path = normalizeRelative(rawPath);
+    if (path === null) {
+      return [Result.ENOTCAPABLE];
     }
 
     if (dir.containsFile(path)) {
@@ -361,6 +449,9 @@ export class WASIDrive {
       const stat = new OpenDirectory(Object.fromEntries(subset), prefix).stat();
       return [Result.SUCCESS, stat];
     } else {
+      // See comment in `open` — preview1 keeps the original
+      // ENOTCAPABLE; the WASIX provider rewrites to ENOENT for POSIX
+      // callers.
       return [Result.ENOTCAPABLE];
     }
   }
@@ -405,12 +496,20 @@ export class WASIDrive {
     }
   }
 
-  pathSetAccessTime(fdDir: FileDescriptor, path: string, date: Date): Result {
+  pathSetAccessTime(
+    fdDir: FileDescriptor,
+    rawPath: string,
+    date: Date,
+  ): Result {
     const dir = this.openMap.get(fdDir);
     if (!(dir instanceof OpenDirectory)) {
       return Result.EBADF;
     }
 
+    const path = normalizeRelative(rawPath);
+    if (path === null) {
+      return Result.ENOTCAPABLE;
+    }
     const f = dir.get(path);
     if (!f) {
       return Result.ENOTCAPABLE;
@@ -423,7 +522,7 @@ export class WASIDrive {
 
   pathSetModificationTime(
     fdDir: FileDescriptor,
-    path: string,
+    rawPath: string,
     date: Date,
   ): Result {
     const dir = this.openMap.get(fdDir);
@@ -431,6 +530,10 @@ export class WASIDrive {
       return Result.EBADF;
     }
 
+    const path = normalizeRelative(rawPath);
+    if (path === null) {
+      return Result.ENOTCAPABLE;
+    }
     const f = dir.get(path);
     if (!f) {
       return Result.ENOTCAPABLE;
@@ -441,10 +544,24 @@ export class WASIDrive {
     return Result.SUCCESS;
   }
 
-  pathCreateDir(fdDir: FileDescriptor, path: string): Result {
+  pathCreateDir(fdDir: FileDescriptor, rawPath: string): Result {
     const dir = this.openMap.get(fdDir);
     if (!(dir instanceof OpenDirectory)) {
       return Result.EBADF;
+    }
+
+    const path = normalizeRelative(rawPath);
+    if (path === null || path === ".") {
+      // "." is the directory itself — already exists.
+      return Result.ENOTCAPABLE;
+    }
+
+    // Reject `mkdir foo/bar` when `foo` doesn't exist or is a regular
+    // file. Mirrors POSIX: mkdir fails ENOENT when a path-prefix
+    // component is missing, ENOTDIR when one is a non-directory.
+    const parentErr = this.validateParent(dir, path);
+    if (parentErr !== null) {
+      return parentErr;
     }
 
     if (dir.contains(path)) {
@@ -679,6 +796,32 @@ class OpenFile {
     newBuffer.set(this.buffer);
     this.buffer = newBuffer;
   }
+}
+
+/**
+ * Strip `./`, `/./` and empty segments from a directory-relative path
+ * so the flat-path drive sees one canonical key per logical entry.
+ * Without this, `mkdirat(cwd, "./test")` would store
+ * `<prefix>./test/.runno` while a sibling `stat("test")` would look
+ * for `<prefix>test/...` and miss it (the create-dir-at-cwd case).
+ *
+ * Returns the normalised path (`"."` for the directory itself), or
+ * `null` if the path contains a `..` segment. The flat-path drive
+ * cannot model traversal-relative paths — a path like `foo/../bar`
+ * needs `foo` to be a real directory before `..` is meaningful, and
+ * the drive has no notion of "real directory" beyond the keys present
+ * in the map. Callers turn `null` into ENOTCAPABLE so the WASI
+ * capability semantics (no escape outside the preopen tree) hold —
+ * matches the existing behaviour for paths the drive can't resolve.
+ */
+function normalizeRelative(path: string): string | null {
+  const out: string[] = [];
+  for (const segment of path.split("/")) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") return null;
+    out.push(segment);
+  }
+  return out.length === 0 ? "." : out.join("/");
 }
 
 function removePrefix(path: string, prefix: string) {

--- a/packages/wasi/lib/wasi/wasi.ts
+++ b/packages/wasi/lib/wasi/wasi.ts
@@ -25,7 +25,7 @@ export type DebugFn = (
   name: string,
   args: string[],
   ret: number,
-  data: { [key: string]: any }[]
+  data: { [key: string]: any }[],
 ) => number | undefined;
 
 let _debugData: { [key: string]: string }[] = [];
@@ -67,12 +67,12 @@ export class WASI implements SnapshotPreview1 {
    */
   static async start(
     wasmSource: Response | PromiseLike<Response>,
-    context: Partial<WASIContextOptions> = {}
+    context: Partial<WASIContextOptions> = {},
   ) {
     const wasi = new WASI(context);
     const wasm = await WebAssembly.instantiateStreaming(
       wasmSource,
-      wasi.getImportObject()
+      wasi.getImportObject(),
     );
     return wasi.start(wasm);
   }
@@ -84,12 +84,12 @@ export class WASI implements SnapshotPreview1 {
    */
   static async initialize(
     wasmSource: Response | PromiseLike<Response>,
-    context: Partial<WASIContextOptions> = {}
+    context: Partial<WASIContextOptions> = {},
   ) {
     const wasi = new WASI(context);
     const wasm = await WebAssembly.instantiateStreaming(
       wasmSource,
-      wasi.getImportObject()
+      wasi.getImportObject(),
     );
     wasi.initialize(wasm);
     return wasm.instance.exports;
@@ -116,11 +116,11 @@ export class WASI implements SnapshotPreview1 {
     wasm: WebAssembly.WebAssemblyInstantiatedSource,
     options: {
       memory?: WebAssembly.Memory;
-    } = {}
+    } = {},
   ): WASIExecutionResult {
     if (this.hasBeenInitialized) {
       throw new InitializationError(
-        "This instance has already been initialized"
+        "This instance has already been initialized",
       );
     }
 
@@ -134,14 +134,14 @@ export class WASI implements SnapshotPreview1 {
     // should be initialized instead
     if ("_initialize" in this.instance.exports) {
       throw new InvalidInstanceError(
-        "WebAssembly instance is a reactor and should be started with initialize."
+        "WebAssembly instance is a reactor and should be started with initialize.",
       );
     }
 
     // If the export doesn't contain `_start` we can't start it
     if (!("_start" in this.instance.exports)) {
       throw new InvalidInstanceError(
-        "WebAssembly instance doesn't export _start, it may not be WASI or may be a Reactor."
+        "WebAssembly instance doesn't export _start, it may not be WASI or may be a Reactor.",
       );
     }
 
@@ -181,11 +181,11 @@ export class WASI implements SnapshotPreview1 {
     wasm: WebAssembly.WebAssemblyInstantiatedSource,
     options: {
       memory?: WebAssembly.Memory;
-    } = {}
+    } = {},
   ) {
     if (this.hasBeenInitialized) {
       throw new InitializationError(
-        "This instance has already been initialized"
+        "This instance has already been initialized",
       );
     }
 
@@ -199,7 +199,7 @@ export class WASI implements SnapshotPreview1 {
     // should be started instead
     if ("_start" in this.instance.exports) {
       throw new InvalidInstanceError(
-        "WebAssembly instance is a command and should be started with start."
+        "WebAssembly instance is a command and should be started with start.",
       );
     }
 
@@ -212,7 +212,7 @@ export class WASI implements SnapshotPreview1 {
 
   getImports(
     version: "unstable" | "preview1",
-    debug?: DebugFn
+    debug?: DebugFn,
   ): WebAssembly.ModuleImports & SnapshotPreview1 {
     const imports = {
       args_get: this.args_get.bind(this),
@@ -304,7 +304,7 @@ export class WASI implements SnapshotPreview1 {
 
   get envArray(): Array<string> {
     return Object.entries(this.context.env).map(
-      ([key, value]) => `${key}=${value}`
+      ([key, value]) => `${key}=${value}`,
     );
   }
 
@@ -326,7 +326,7 @@ export class WASI implements SnapshotPreview1 {
       const buffer = new Uint8Array(
         this.memory.buffer,
         argv_buf_ptr,
-        data.byteLength
+        data.byteLength,
       );
       buffer.set(data);
       argv_buf_ptr += data.byteLength;
@@ -402,7 +402,7 @@ export class WASI implements SnapshotPreview1 {
       const buffer = new Uint8Array(
         this.memory.buffer,
         env_buf_ptr,
-        data.byteLength
+        data.byteLength,
       );
       buffer.set(data);
       env_buf_ptr += data.byteLength;
@@ -468,7 +468,7 @@ export class WASI implements SnapshotPreview1 {
     fd: number,
     iovs_ptr: number,
     iovs_len: number,
-    retptr0: number
+    retptr0: number,
   ): number {
     // Read not supported on stdout and stderr
     if (fd === 1 || fd === 2) {
@@ -523,7 +523,7 @@ export class WASI implements SnapshotPreview1 {
     fd: number,
     ciovs_ptr: number,
     ciovs_len: number,
-    retptr0: number
+    retptr0: number,
   ): number {
     // Write not supported on STDIN
     if (fd === 0) {
@@ -545,7 +545,11 @@ export class WASI implements SnapshotPreview1 {
       // STDOUT or STDERR
       if (fd === 1 || fd === 2) {
         const stdfn = fd === 1 ? this.context.stdout : this.context.stderr;
-        const output = decoder.decode(iov);
+        // Copy before decoding: a WASIX guest with shared env.memory
+        // hands us views over a SharedArrayBuffer, which TextDecoder
+        // refuses. Single fresh allocation per write keeps the preview1
+        // path unchanged.
+        const output = decoder.decode(iov.slice());
         stdfn(output);
 
         pushDebugData({ output });
@@ -580,7 +584,7 @@ export class WASI implements SnapshotPreview1 {
     return this.drive.pwrite(
       fd,
       new Uint8Array(Number(length)),
-      Number(offset)
+      Number(offset),
     );
   }
 
@@ -628,7 +632,7 @@ export class WASI implements SnapshotPreview1 {
       const retBuffer = new Uint8Array(
         this.memory.buffer,
         retptr0,
-        buffer.byteLength
+        buffer.byteLength,
       );
       retBuffer.set(buffer);
 
@@ -645,7 +649,7 @@ export class WASI implements SnapshotPreview1 {
     const retBuffer = new Uint8Array(
       this.memory.buffer,
       retptr0,
-      buffer.byteLength
+      buffer.byteLength,
     );
     retBuffer.set(buffer);
 
@@ -691,7 +695,7 @@ export class WASI implements SnapshotPreview1 {
   shared_fd_filestat_get(
     fd: number,
     retptr0: number,
-    version: "unstable" | "preview1"
+    version: "unstable" | "preview1",
   ): number {
     const createFilestatFn =
       version === "unstable" ? createUnstableFilestat : createFilestat;
@@ -726,7 +730,7 @@ export class WASI implements SnapshotPreview1 {
       const retBuffer = new Uint8Array(
         this.memory.buffer,
         retptr0,
-        buffer.byteLength
+        buffer.byteLength,
       );
       retBuffer.set(buffer);
 
@@ -744,7 +748,7 @@ export class WASI implements SnapshotPreview1 {
     const returnBuffer = new Uint8Array(
       this.memory.buffer,
       retptr0,
-      data.byteLength
+      data.byteLength,
     );
     returnBuffer.set(data);
 
@@ -768,7 +772,7 @@ export class WASI implements SnapshotPreview1 {
     fd: number,
     atim: bigint,
     mtim: bigint,
-    fst_flags: number
+    fst_flags: number,
   ): number {
     let accessTime: Date | null = null;
     if (fst_flags & FileStatTimestampFlags.ATIM) {
@@ -812,7 +816,7 @@ export class WASI implements SnapshotPreview1 {
     iovs_ptr: number,
     iovs_len: number,
     offset: bigint,
-    retptr0: number
+    retptr0: number,
   ): number {
     // Read not supported on stdout and stderr
     if (fd === 1 || fd === 2) {
@@ -833,7 +837,7 @@ export class WASI implements SnapshotPreview1 {
       const [error, value] = this.drive.pread(
         fd,
         iov.byteLength,
-        Number(offset) + bytesRead
+        Number(offset) + bytesRead,
       );
       if (error !== Result.SUCCESS) {
         result = error;
@@ -893,7 +897,7 @@ export class WASI implements SnapshotPreview1 {
     ciovs_ptr: number,
     ciovs_len: number,
     offset: bigint,
-    retptr0: number
+    retptr0: number,
   ): number {
     // Write not supported on STDIN
     if (fd === 0) {
@@ -942,7 +946,7 @@ export class WASI implements SnapshotPreview1 {
     buf: number,
     buf_len: number,
     cookie: bigint,
-    retptr0: number
+    retptr0: number,
   ): number {
     const [result, list] = this.drive.list(fd);
     if (result != Result.SUCCESS) {
@@ -1015,7 +1019,7 @@ export class WASI implements SnapshotPreview1 {
     fd: number,
     offset: bigint,
     whence: number,
-    retptr0: number
+    retptr0: number,
   ) {
     const newWhence = UNSTABLE_WHENCE_MAP[whence as UnstableWhence];
     return this.fd_seek(fd, offset, newWhence, retptr0);
@@ -1056,7 +1060,7 @@ export class WASI implements SnapshotPreview1 {
     flags: number,
     path_ptr: number,
     path_len: number,
-    retptr0: number
+    retptr0: number,
   ): number {
     return this.shared_path_filestat_get(
       fd,
@@ -1064,7 +1068,7 @@ export class WASI implements SnapshotPreview1 {
       path_ptr,
       path_len,
       retptr0,
-      "preview1"
+      "preview1",
     );
   }
 
@@ -1073,7 +1077,7 @@ export class WASI implements SnapshotPreview1 {
     flags: number,
     path_ptr: number,
     path_len: number,
-    retptr0: number
+    retptr0: number,
   ): number {
     return this.shared_path_filestat_get(
       fd,
@@ -1081,7 +1085,7 @@ export class WASI implements SnapshotPreview1 {
       path_ptr,
       path_len,
       retptr0,
-      "unstable"
+      "unstable",
     );
   }
 
@@ -1095,13 +1099,13 @@ export class WASI implements SnapshotPreview1 {
     path_ptr: number,
     path_len: number,
     retptr0: number,
-    version: "unstable" | "preview1"
+    version: "unstable" | "preview1",
   ): number {
     const createFilestatFn =
       version === "unstable" ? createUnstableFilestat : createFilestat;
 
     const path = new TextDecoder().decode(
-      new Uint8Array(this.memory.buffer, path_ptr, path_len)
+      new Uint8Array(this.memory.buffer, path_ptr, path_len).slice(),
     );
 
     pushDebugData({ path });
@@ -1115,7 +1119,7 @@ export class WASI implements SnapshotPreview1 {
     const returnBuffer = new Uint8Array(
       this.memory.buffer,
       retptr0,
-      statBuffer.byteLength
+      statBuffer.byteLength,
     );
     returnBuffer.set(statBuffer);
 
@@ -1133,7 +1137,7 @@ export class WASI implements SnapshotPreview1 {
     path_len: number,
     atim: bigint,
     mtim: bigint,
-    fst_flags: number
+    fst_flags: number,
   ): number {
     let accessTime: Date | null = null;
     if (fst_flags & FileStatTimestampFlags.ATIM) {
@@ -1152,7 +1156,7 @@ export class WASI implements SnapshotPreview1 {
     }
 
     const path = new TextDecoder().decode(
-      new Uint8Array(this.memory.buffer, path_ptr, path_len)
+      new Uint8Array(this.memory.buffer, path_ptr, path_len).slice(),
     );
 
     if (accessTime) {
@@ -1166,7 +1170,7 @@ export class WASI implements SnapshotPreview1 {
       const result = this.drive.pathSetModificationTime(
         fd,
         path,
-        modificationTime
+        modificationTime,
       );
       if (result != Result.SUCCESS) {
         return result;
@@ -1213,7 +1217,7 @@ export class WASI implements SnapshotPreview1 {
     // @ts-expect-error - same as above
     rights_inheriting: bigint,
     fdflags: number,
-    retptr0: number
+    retptr0: number,
   ): number {
     const view = new DataView(this.memory.buffer);
     const path = readString(this.memory, path_ptr, path_len);
@@ -1264,7 +1268,7 @@ export class WASI implements SnapshotPreview1 {
     old_path_len: number,
     new_fd_dir: number,
     new_path_ptr: number,
-    new_path_len: number
+    new_path_len: number,
   ): number {
     const oldPath = readString(this.memory, old_path_ptr, old_path_len);
     const newPath = readString(this.memory, new_path_ptr, new_path_len);
@@ -1292,20 +1296,20 @@ export class WASI implements SnapshotPreview1 {
     in_ptr: number,
     out_ptr: number,
     nsubscriptions: number,
-    retptr0: number
+    retptr0: number,
   ): number {
     for (let i = 0; i < nsubscriptions; i++) {
       const subscriptionBuffer = new Uint8Array(
         this.memory.buffer,
         in_ptr + i * SUBSCRIPTION_SIZE,
-        SUBSCRIPTION_SIZE
+        SUBSCRIPTION_SIZE,
       );
       const subscription = readSubscription(subscriptionBuffer);
 
       const eventBuffer = new Uint8Array(
         this.memory.buffer,
         out_ptr + i * EVENT_SIZE,
-        EVENT_SIZE
+        EVENT_SIZE,
       );
       let byteLength = 0;
       let result: Result = Result.SUCCESS;
@@ -1315,7 +1319,7 @@ export class WASI implements SnapshotPreview1 {
             // Wait until we hit the event time
           }
           eventBuffer.set(
-            createClockEvent(subscription.userdata, Result.SUCCESS)
+            createClockEvent(subscription.userdata, Result.SUCCESS),
           );
           break;
         case EventType.FD_READ:
@@ -1339,8 +1343,8 @@ export class WASI implements SnapshotPreview1 {
               subscription.userdata,
               result,
               EventType.FD_READ,
-              BigInt(byteLength)
-            )
+              BigInt(byteLength),
+            ),
           );
           break;
         case EventType.FD_WRITE:
@@ -1366,8 +1370,8 @@ export class WASI implements SnapshotPreview1 {
               subscription.userdata,
               result,
               EventType.FD_READ,
-              BigInt(byteLength)
-            )
+              BigInt(byteLength),
+            ),
           );
           break;
       }
@@ -1385,7 +1389,7 @@ export class WASI implements SnapshotPreview1 {
   path_create_directory(
     fd: number,
     path_ptr: number,
-    path_len: number
+    path_len: number,
   ): number {
     const path = readString(this.memory, path_ptr, path_len);
     return this.drive.pathCreateDir(fd, path);
@@ -1552,7 +1556,12 @@ class WASIExit extends Error {
  * @returns the string at that address
  */
 function readString(memory: WebAssembly.Memory, ptr: number, len: number) {
-  return new TextDecoder().decode(new Uint8Array(memory.buffer, ptr, len));
+  // Copy before decoding so callers with a SharedArrayBuffer-backed
+  // memory (WASIX guests) don't trip TextDecoder's "shared view"
+  // rejection. Cheap for typical preview1 paths (single short read).
+  return new TextDecoder().decode(
+    new Uint8Array(memory.buffer, ptr, len).slice(),
+  );
 }
 
 /**
@@ -1567,7 +1576,7 @@ function readString(memory: WebAssembly.Memory, ptr: number, len: number) {
 function readIOVectors(
   view: DataView,
   iovs_ptr: number,
-  iovs_len: number
+  iovs_len: number,
 ): Array<Uint8Array> {
   let result = Array<Uint8Array>(iovs_len);
 
@@ -1731,7 +1740,7 @@ function createUnstableFilestat(stat: DriveStat): Uint8Array {
 function createFdStat(
   type: FileType,
   fdflags: number,
-  rights?: bigint
+  rights?: bigint,
 ): Uint8Array {
   const rightsBase = rights ?? ALL_RIGHTS;
   const rightsInheriting = rights ?? ALL_RIGHTS;
@@ -1762,7 +1771,7 @@ function createFdStat(
 function createDirectoryEntry(
   name: string,
   type: FileType,
-  currentIndex: number
+  currentIndex: number,
 ): Uint8Array {
   // Each entry is made up of:
   // 0 - d_next = dircookie (size: 8) the offset of the next directory entry
@@ -1819,7 +1828,7 @@ function createFDReadWriteEvent(
   userdata: Uint8Array,
   error: Result,
   type: EventType.FD_READ | EventType.FD_WRITE,
-  nbytes: bigint
+  nbytes: bigint,
 ): Uint8Array {
   const eventBuffer = new Uint8Array(32);
   eventBuffer.set(userdata, 0);

--- a/packages/wasi/lib/wasix/providers/ergonomic/filesystem-provider.ts
+++ b/packages/wasi/lib/wasix/providers/ergonomic/filesystem-provider.ts
@@ -62,8 +62,18 @@ function dateToNs(date: Date): bigint {
  * `EACCESS` alongside the same numeric slot; wasix uses the canonical
  * `EACCES` spelling with the same value). A numeric cast is therefore
  * exact and round-trip-safe for the ergonomic wrapper's purposes.
+ *
+ * The drive returns `ENOTCAPABLE` for both "path missing" and
+ * "capability denied" because the flat-path map can't distinguish them.
+ * POSIX-shaped binaries (wasix-libc) check `errno == ENOENT` to detect
+ * absent paths, so we rewrite `ENOTCAPABLE` to `ENOENT` here for path
+ * lookups. Preview1 callers go through wasi.ts directly and still see
+ * the original code (the WASI test suite asserts on it).
  */
 function toWasixResult(err: Preview1Result): Result {
+  if (err === Preview1Result.ENOTCAPABLE) {
+    return Result.ENOENT;
+  }
   return err as unknown as Result;
 }
 
@@ -246,12 +256,36 @@ export class WASIDriveFileSystemProvider implements FileSystemProvider {
     if (cookie > BigInt(Number.MAX_SAFE_INTEGER)) {
       throw new WASIXError(Result.EOVERFLOW);
     }
-    const entries: DirEntry[] = list.map((entry, index) => ({
-      next: BigInt(index + 1),
-      ino: cyrb53Bigint(entry.name),
-      filetype: entry.type as unknown as FileType,
-      name: entry.name,
-    }));
+    // Drop the `.runno` sentinel that `WASIDrive.pathCreateDir` plants
+    // in every mkdir'd directory — it's a flat-path-map artefact and
+    // not a real entry the guest ever wrote. Going away with the
+    // drive extraction in a later slice.
+    const realEntries = list.filter((entry) => entry.name !== ".runno");
+    // Synthesize POSIX `.` and `..` entries. wasix-libc's readdir
+    // implementation passes them through verbatim (matches every
+    // hosted-libc behaviour the wasmer suite asserts against), and
+    // omitting them breaks tests like closing-pre-opened-dirs that
+    // grep for `.` in the listing.
+    const entries: DirEntry[] = [
+      {
+        next: 1n,
+        ino: 0n,
+        filetype: FileType.DIRECTORY,
+        name: ".",
+      },
+      {
+        next: 2n,
+        ino: 0n,
+        filetype: FileType.DIRECTORY,
+        name: "..",
+      },
+      ...realEntries.map((entry, index) => ({
+        next: BigInt(index + 3),
+        ino: cyrb53Bigint(entry.name),
+        filetype: entry.type as unknown as FileType,
+        name: entry.name,
+      })),
+    ];
     const startIndex = Number(cookie);
     return entries.slice(startIndex);
   }

--- a/packages/wasi/lib/wasix/providers/ergonomic/filesystem-provider.ts
+++ b/packages/wasi/lib/wasix/providers/ergonomic/filesystem-provider.ts
@@ -10,6 +10,7 @@
 
 import { WASIFS } from "../../../types.js";
 import { WASIDrive } from "../../../wasi/wasi-drive.js";
+import type { WASIDrivePreopen } from "../../../wasi/wasi-drive.js";
 // The WASIDrive is a preview1 artefact; its Result enum mirrors
 // wasix-32v1.Result numerically. We read preview1 error codes directly
 // and pass them straight to WASIXError (whose constructor accepts the
@@ -67,6 +68,31 @@ function toWasixResult(err: Preview1Result): Result {
 }
 
 /**
+ * One preopen exposed by the provider beyond the implicit fd 3 = ".".
+ * Each maps a guest-visible name (e.g. "/home") to a drive prefix
+ * (always rooted, trailing slash) used when resolving paths through
+ * the bound fd.
+ */
+export type ProviderPreopen = {
+  /** Guest-visible name returned by `fd_prestat_dir_name`. */
+  name: string;
+  /** Drive-internal prefix used when storing / resolving entries. */
+  prefix: string;
+};
+
+export type WASIDriveFileSystemProviderOptions = {
+  /**
+   * Extra preopens beyond the default fd 3 = ".". Bound to consecutive
+   * fds starting at 4 in the order supplied.
+   *
+   * Required to expose mounts that wasix-libc expects to find by
+   * absolute prefix (e.g. wasix-libc's default cwd is `/home`, so a
+   * `/home` preopen is needed for cwd-relative file ops to resolve).
+   */
+  preopens?: ProviderPreopen[];
+};
+
+/**
  * Ergonomic filesystem provider that delegates to the existing in-memory
  * `WASIDrive`. Hosts construct one with a `WASIFS` (or an existing drive)
  * and pass it as `WASIXContext.fs`.
@@ -74,9 +100,38 @@ function toWasixResult(err: Preview1Result): Result {
 export class WASIDriveFileSystemProvider implements FileSystemProvider {
   readonly drive: WASIDrive;
 
-  constructor(fsOrDrive: WASIFS | WASIDrive) {
-    this.drive =
-      fsOrDrive instanceof WASIDrive ? fsOrDrive : new WASIDrive(fsOrDrive);
+  /** fd → guest-visible preopen name. fd 3 always maps to ".". */
+  private readonly preopenNames: Map<number, string>;
+
+  constructor(
+    fsOrDrive: WASIFS | WASIDrive,
+    options?: WASIDriveFileSystemProviderOptions,
+  ) {
+    this.preopenNames = new Map();
+    this.preopenNames.set(3, ".");
+
+    if (fsOrDrive instanceof WASIDrive) {
+      this.drive = fsOrDrive;
+      // Trust the caller — assume any preopens beyond fd 3 are already
+      // registered on the drive. Mirror them here so prestat reads find
+      // the names.
+      if (options?.preopens) {
+        let nextFd = 4;
+        for (const p of options.preopens) {
+          this.preopenNames.set(nextFd++, p.name);
+        }
+      }
+    } else {
+      const drivePreopens: WASIDrivePreopen[] | undefined =
+        options?.preopens?.map((p) => ({ prefix: p.prefix }));
+      this.drive = new WASIDrive(fsOrDrive, { preopens: drivePreopens });
+      if (options?.preopens) {
+        let nextFd = 4;
+        for (const p of options.preopens) {
+          this.preopenNames.set(nextFd++, p.name);
+        }
+      }
+    }
   }
 
   // ─── File descriptor ops ──────────────────────────────────────────────
@@ -166,18 +221,16 @@ export class WASIDriveFileSystemProvider implements FileSystemProvider {
   }
 
   fdPrestatGet(fd: number): PreopenInfo | null {
-    // WASIDrive hard-codes fd 3 as the single preopen at "/".
-    if (fd !== 3) {
-      return null;
-    }
-    return { name: "." };
+    const name = this.preopenNames.get(fd);
+    return name === undefined ? null : { name };
   }
 
   fdPrestatDirName(fd: number): string {
-    if (fd !== 3) {
+    const name = this.preopenNames.get(fd);
+    if (name === undefined) {
       throw new WASIXError(Result.EBADF);
     }
-    return ".";
+    return name;
   }
 
   fdReaddir(fd: number, cookie: bigint): DirEntry[] {

--- a/packages/wasi/lib/wasix/wasix-context.ts
+++ b/packages/wasi/lib/wasix/wasix-context.ts
@@ -33,6 +33,14 @@ export type WASIXContextOptions = {
   signals?: SignalsProvider;
   sockets?: SocketsProvider;
   proc?: ProcProvider;
+
+  // Optional overrides for the import surface that WASIX otherwise
+  // auto-detects from the module's import section. Hosts pass these
+  // when reusing a `WebAssembly.Memory` / `WebAssembly.Table` across
+  // sibling instances (the threaded configuration). When unset the
+  // runtime constructs new ones to match the import descriptor.
+  memory?: WebAssembly.Memory;
+  indirectFunctionTable?: WebAssembly.Table;
 };
 
 /**
@@ -65,6 +73,9 @@ export class WASIXContext {
   sockets?: SocketsProvider;
   proc?: ProcProvider;
 
+  memory?: WebAssembly.Memory;
+  indirectFunctionTable?: WebAssembly.Table;
+
   constructor(options?: Partial<WASIXContextOptions>) {
     this.fs = options?.fs ?? new WASIDriveFileSystemProvider({});
     this.args = options?.args ?? [];
@@ -84,5 +95,8 @@ export class WASIXContext {
     this.signals = options?.signals;
     this.sockets = options?.sockets;
     this.proc = options?.proc;
+
+    this.memory = options?.memory;
+    this.indirectFunctionTable = options?.indirectFunctionTable;
   }
 }

--- a/packages/wasi/lib/wasix/wasix.ts
+++ b/packages/wasi/lib/wasix/wasix.ts
@@ -214,11 +214,34 @@ export class WASIX {
     // surface. Override the preview1 entries so the FS provider's
     // preopen map (e.g. fd 4 = "/home") is visible to the libc startup
     // walk; otherwise it stops after fd 3 and never finds /home.
+    //
+    // Path ops are also routed through the FS provider when libc
+    // happens to import the preview1 entry instead of the wasix_32v1
+    // one. wasix-libc 0.4.3 does this for `rmdir` (preview1
+    // `path_remove_directory`); the preview1 stub in wasi.ts returns
+    // ENOSYS, so without this override `rmdir` always fails even
+    // though the drive can perform it. Mirror the syscalls that have
+    // a richer semantics in the provider (e.g. ENOTEMPTY checks).
+    // wasix-libc reaches into preview1 for several path/fd ops even
+    // when the binary is otherwise wasix_32v1 (rmdir → preview1
+    // `path_remove_directory`, stat → preview1 `path_filestat_get`,
+    // readdir → preview1 `fd_readdir`). The preview1 impls in wasi.ts
+    // call the drive directly and return its raw error vocabulary
+    // (e.g. ENOTCAPABLE for "not present") and don't synthesize the
+    // POSIX-shaped readdir entries (`.` / `..`, no `.runno`). Route
+    // them through the WASIX provider so the translation is uniform.
     const preview1Overrides = {
       ...preview1,
       proc_exit: procExit,
       fd_prestat_get: this.wasix_fd_prestat_get.bind(this),
       fd_prestat_dir_name: this.wasix_fd_prestat_dir_name.bind(this),
+      fd_readdir: this.wasix_fd_readdir.bind(this),
+      path_filestat_get: this.wasix_path_filestat_get.bind(this),
+      path_open: this.wasix_path_open.bind(this),
+      path_create_directory: this.wasix_path_create_directory.bind(this),
+      path_remove_directory: this.wasix_path_remove_directory.bind(this),
+      path_unlink_file: this.wasix_path_unlink_file.bind(this),
+      path_rename: this.wasix_path_rename.bind(this),
     };
     return {
       env: envImports,

--- a/packages/wasi/lib/wasix/wasix.ts
+++ b/packages/wasi/lib/wasix/wasix.ts
@@ -33,6 +33,14 @@ class WASIXExit extends Error {
   }
 }
 
+// One-shot warning: emitted on first construction when the host page is
+// not cross-origin-isolated. wasix-libc binaries import a shared
+// `env.memory`, which `WebAssembly.instantiate` rejects without
+// `crossOriginIsolated`. Without this hint the failure looks like a
+// generic "imported memory: shared but env doesn't allow shared memory"
+// error from the engine.
+let warnedNotCrossOriginIsolated = false;
+
 /**
  * WASIX runtime for the browser.
  *
@@ -59,21 +67,41 @@ export class WASIX {
 
   /**
    * Start a WASIX command.
+   *
+   * Compiles the module first so we can inspect its imports for
+   * `env.memory` / `env.__indirect_function_table` and supply a matching
+   * `WebAssembly.Memory` / `WebAssembly.Table` (constructed here, or
+   * passed in via `WASIXContextOptions.memory` / `.indirectFunctionTable`).
    */
   static async start(
     wasmSource: Response | PromiseLike<Response>,
     context: Partial<WASIXContextOptions> = {},
   ): Promise<WASIXExecutionResult> {
     const wasix = new WASIX(context);
-    const wasm = await WebAssembly.instantiateStreaming(
-      wasmSource,
-      wasix.getImportObject(),
-    );
-    return wasix.start(wasm);
+    const module = await WebAssembly.compileStreaming(wasmSource);
+    const { memory, indirectFunctionTable } = wasix.resolveEnvImports(module);
+    const imports = wasix.getImportObject({ memory, indirectFunctionTable });
+    const instance = await WebAssembly.instantiate(module, imports);
+    return wasix.start({ module, instance }, { memory });
   }
 
   constructor(context: Partial<WASIXContextOptions>) {
     this.context = new WASIXContext(context);
+
+    if (
+      !warnedNotCrossOriginIsolated &&
+      typeof globalThis !== "undefined" &&
+      (globalThis as { crossOriginIsolated?: boolean }).crossOriginIsolated ===
+        false
+    ) {
+      warnedNotCrossOriginIsolated = true;
+      console.warn(
+        "WASIX: page is not cross-origin-isolated; shared-memory imports " +
+          "will fail at WebAssembly.instantiate. Configure COOP " +
+          "(`Cross-Origin-Opener-Policy: same-origin`) and COEP " +
+          "(`Cross-Origin-Embedder-Policy: require-corp`) on the host page.",
+      );
+    }
     // The internal WASI shares args / env / stdio with WASIX. The WASIX
     // filesystem surface routes through `context.fs` (a FileSystemProvider),
     // so the internal WASI's preview1 fs is intentionally empty — guests
@@ -91,7 +119,89 @@ export class WASIX {
     this.wasi = new WASI(wasiContext);
   }
 
-  getImportObject() {
+  /**
+   * Inspect the compiled module's imports for `env.memory` and
+   * `env.__indirect_function_table`. For each that's present, either
+   * validate the host-supplied override against the import descriptor
+   * or construct a fresh `WebAssembly.Memory` / `WebAssembly.Table`
+   * matching the declared shape. Returns whichever values the import
+   * object should use for the `env` namespace; either may be undefined
+   * (e.g. preview1-style binaries that export their own memory).
+   */
+  resolveEnvImports(module: WebAssembly.Module): {
+    memory?: WebAssembly.Memory;
+    indirectFunctionTable?: WebAssembly.Table;
+  } {
+    let memory: WebAssembly.Memory | undefined;
+    let indirectFunctionTable: WebAssembly.Table | undefined;
+
+    for (const entry of WebAssembly.Module.imports(module)) {
+      if (entry.module !== "env") continue;
+
+      if (entry.kind === "memory" && entry.name === "memory") {
+        // The import descriptor (`MemoryDescriptor`) is exposed on the
+        // entry across browsers as the bag of `initial`/`maximum`/`shared`
+        // fields. Type definitions don't surface it yet, so cast.
+        const descriptor = (
+          entry as unknown as { type?: WebAssembly.MemoryDescriptor }
+        ).type;
+        const initial = descriptor?.initial ?? 0;
+        const maximum = descriptor?.maximum;
+        const shared =
+          (descriptor as { shared?: boolean } | undefined)?.shared ?? false;
+
+        const override = this.context.memory;
+        if (override) {
+          validateMemoryOverride(override, { initial, maximum, shared });
+          memory = override;
+        } else {
+          memory = new WebAssembly.Memory({
+            initial,
+            ...(maximum !== undefined ? { maximum } : {}),
+            ...(shared ? { shared: true } : {}),
+          } as WebAssembly.MemoryDescriptor);
+        }
+        continue;
+      }
+
+      if (
+        entry.kind === "table" &&
+        entry.name === "__indirect_function_table"
+      ) {
+        const descriptor = (
+          entry as unknown as { type?: WebAssembly.TableDescriptor }
+        ).type;
+        const element = (descriptor?.element ?? "funcref") as
+          | "anyfunc"
+          | "funcref"
+          | "externref";
+        const initial = descriptor?.initial ?? 0;
+        const maximum = descriptor?.maximum;
+
+        const override = this.context.indirectFunctionTable;
+        if (override) {
+          validateTableOverride(override, { element, initial, maximum });
+          indirectFunctionTable = override;
+        } else {
+          indirectFunctionTable = new WebAssembly.Table({
+            element,
+            initial,
+            ...(maximum !== undefined ? { maximum } : {}),
+          } as WebAssembly.TableDescriptor);
+        }
+        continue;
+      }
+    }
+
+    return { memory, indirectFunctionTable };
+  }
+
+  getImportObject(
+    env: {
+      memory?: WebAssembly.Memory;
+      indirectFunctionTable?: WebAssembly.Table;
+    } = {},
+  ) {
     const preview1 = this.wasi.getImports("preview1", this.context.debug);
     const unstable = this.wasi.getImports("unstable", this.context.debug);
 
@@ -101,7 +211,13 @@ export class WASIX {
       throw new WASIXExit(code);
     };
 
+    const envImports: WebAssembly.ModuleImports = {};
+    if (env.memory) envImports.memory = env.memory;
+    if (env.indirectFunctionTable)
+      envImports.__indirect_function_table = env.indirectFunctionTable;
+
     return {
+      env: envImports,
       wasix_32v1: this.getWasix32v1Imports(),
       wasi_snapshot_preview1: { ...preview1, proc_exit: procExit },
       wasi_unstable: { ...unstable, proc_exit: procExit },
@@ -666,6 +782,50 @@ export class WASIX {
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
+
+function validateMemoryOverride(
+  memory: WebAssembly.Memory,
+  descriptor: { initial: number; maximum?: number; shared: boolean },
+): void {
+  // Engines expose memory.buffer as a SharedArrayBuffer when the
+  // underlying memory is shared.
+  const overrideShared =
+    typeof SharedArrayBuffer !== "undefined" &&
+    memory.buffer instanceof SharedArrayBuffer;
+  if (overrideShared !== descriptor.shared) {
+    throw new Error(
+      `WASIX: provided memory.shared=${overrideShared} does not match ` +
+        `module's env.memory.shared=${descriptor.shared}`,
+    );
+  }
+  const overrideInitial = memory.buffer.byteLength / 65536;
+  if (overrideInitial < descriptor.initial) {
+    throw new Error(
+      `WASIX: provided memory has ${overrideInitial} pages but ` +
+        `module's env.memory requires initial=${descriptor.initial}`,
+    );
+  }
+  // Maximum is not directly observable on the JS side without a private
+  // grow attempt, so we rely on the engine to reject at instantiation
+  // time if the override's max is below the descriptor's max.
+}
+
+function validateTableOverride(
+  table: WebAssembly.Table,
+  descriptor: { element: string; initial: number; maximum?: number },
+): void {
+  if (table.length < descriptor.initial) {
+    throw new Error(
+      `WASIX: provided indirect function table has length ${table.length} ` +
+        `but module's env.__indirect_function_table requires ` +
+        `initial=${descriptor.initial}`,
+    );
+  }
+  // Element type is not introspectable from JS; the engine rejects on
+  // mismatch at instantiation time. Maximum likewise.
+  void descriptor.element;
+  void descriptor.maximum;
+}
 
 function readString(
   memory: WebAssembly.Memory,

--- a/packages/wasi/lib/wasix/wasix.ts
+++ b/packages/wasi/lib/wasix/wasix.ts
@@ -621,6 +621,12 @@ export class WASIX {
 
   private getWasix32v1Imports(): WebAssembly.ModuleImports {
     const enosys = () => Result.ENOSYS;
+    // proc_exit2 mirrors proc_exit semantics: terminate the run with the
+    // supplied code. wasix-libc's exit path always goes through proc_exit2;
+    // proc_exit (v1) is left wired ENOSYS until a binary surfaces it.
+    const procExit2 = (code: number) => {
+      throw new WASIXExit(code);
+    };
     return {
       // Args / environ — share the internal WASI's preview1 implementations
       // so wasix-libc's argv/environ setup sees the values that were passed
@@ -660,12 +666,23 @@ export class WASIX {
       fd_write: this.wasix_fd_write.bind(this),
       fd_pipe: enosys,
 
+      // wasix_32v1 v2 fd surface — flag-extended variants. Stubbed
+      // ENOSYS until the fd-table extraction (Slice 9) lifts the
+      // backing semantics out of WASIDrive.
+      fd_dup2: enosys, // TODO(slice-9): alias of fd_renumber
+      fd_fdflags_get: enosys, // TODO(slice-9): mirrors fd_fdstat_get fs_flags
+      fd_fdflags_set: enosys, // TODO(slice-9): mirrors fd_fdstat_set_flags
+
       // Paths
       path_create_directory: this.wasix_path_create_directory.bind(this),
       path_filestat_get: this.wasix_path_filestat_get.bind(this),
       path_filestat_set_times: enosys,
       path_link: enosys,
       path_open: this.wasix_path_open.bind(this),
+      // TODO(slice-9): path_open2 carries an extended fdflags arg; for now
+      // it returns ENOSYS so binaries that link both v1 and v2 can still
+      // instantiate, since the v1 path_open is already wired.
+      path_open2: enosys,
       path_readlink: enosys,
       path_remove_directory: this.wasix_path_remove_directory.bind(this),
       path_rename: this.wasix_path_rename.bind(this),
@@ -674,12 +691,18 @@ export class WASIX {
 
       // Process
       proc_exit: enosys,
+      proc_exit2: procExit2,
       proc_fork: enosys,
+      proc_fork_env: enosys, // TODO(slice-7): proc/fork provider
       proc_exec: enosys,
+      proc_exec3: enosys, // TODO(slice-7): proc/exec provider
       proc_join: enosys,
       proc_signal: enosys,
+      proc_signals_get: enosys, // TODO(slice-8): signals provider
+      proc_signals_sizes_get: enosys, // TODO(slice-8): signals provider
       proc_raise: enosys,
       proc_spawn: enosys,
+      proc_spawn2: enosys, // TODO(slice-7): proc/spawn provider
       proc_id: enosys,
       proc_parent: enosys,
 

--- a/packages/wasi/lib/wasix/wasix.ts
+++ b/packages/wasi/lib/wasix/wasix.ts
@@ -19,6 +19,7 @@ import { WASIContextOptions } from "../wasi/wasi-context.js";
 import { WASIXExecutionResult } from "../types.js";
 import { SystemClockProvider } from "./providers/system-clock.js";
 import { SystemRandomProvider } from "./providers/system-random.js";
+import { WASIDriveFileSystemProvider } from "./providers/ergonomic/filesystem-provider.js";
 import type {
   ClockProvider,
   FileSystemProvider,
@@ -68,18 +69,25 @@ export class WASIX {
   /**
    * Start a WASIX command.
    *
-   * Compiles the module first so we can inspect its imports for
-   * `env.memory` / `env.__indirect_function_table` and supply a matching
-   * `WebAssembly.Memory` / `WebAssembly.Table` (constructed here, or
-   * passed in via `WASIXContextOptions.memory` / `.indirectFunctionTable`).
+   * Buffers the module bytes so we can parse the import section
+   * ourselves: `WebAssembly.Module.imports(module)` returns only the
+   * `{ module, name, kind }` triple — descriptors (memory limits,
+   * shared flag, table element type) are not in the standard surface.
+   * We need those to construct a matching `WebAssembly.Memory` /
+   * `WebAssembly.Table` for `env.memory` / `env.__indirect_function_table`,
+   * so the parse runs over the raw bytes before compile.
    */
   static async start(
     wasmSource: Response | PromiseLike<Response>,
     context: Partial<WASIXContextOptions> = {},
   ): Promise<WASIXExecutionResult> {
     const wasix = new WASIX(context);
-    const module = await WebAssembly.compileStreaming(wasmSource);
-    const { memory, indirectFunctionTable } = wasix.resolveEnvImports(module);
+    const response = await wasmSource;
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    const envDescriptors = parseEnvImportDescriptors(bytes);
+    const { memory, indirectFunctionTable } =
+      wasix.resolveEnvImports(envDescriptors);
+    const module = await WebAssembly.compile(bytes);
     const imports = wasix.getImportObject({ memory, indirectFunctionTable });
     const instance = await WebAssembly.instantiate(module, imports);
     return wasix.start({ module, instance }, { memory });
@@ -102,10 +110,15 @@ export class WASIX {
           "(`Cross-Origin-Embedder-Policy: require-corp`) on the host page.",
       );
     }
-    // The internal WASI shares args / env / stdio with WASIX. The WASIX
-    // filesystem surface routes through `context.fs` (a FileSystemProvider),
-    // so the internal WASI's preview1 fs is intentionally empty — guests
-    // built against wasix_32v1 should not be reaching for preview1 fs.
+    // The internal WASI shares args / env / stdio with WASIX. wasix-libc
+    // binaries reach for both `wasix_32v1` and `wasi_snapshot_preview1`
+    // filesystem imports — preopen discovery (`fd_prestat_get`) lives in
+    // preview1 — so the inner WASI must see the same drive as the WASIX
+    // FileSystemProvider, not a separate empty drive. When the host hands
+    // us the bundled `WASIDriveFileSystemProvider` we reuse its drive
+    // directly; for opaque providers the inner preview1 fs stays empty
+    // (those hosts shouldn't have wasix-libc binaries reaching for
+    // preview1 fs in the first place).
     const wasiContext: Partial<WASIContextOptions> = {
       args: context.args,
       env: context.env,
@@ -117,79 +130,52 @@ export class WASIX {
       fs: {},
     };
     this.wasi = new WASI(wasiContext);
+    if (this.context.fs instanceof WASIDriveFileSystemProvider) {
+      this.wasi.drive = this.context.fs.drive;
+    }
   }
 
   /**
-   * Inspect the compiled module's imports for `env.memory` and
-   * `env.__indirect_function_table`. For each that's present, either
-   * validate the host-supplied override against the import descriptor
-   * or construct a fresh `WebAssembly.Memory` / `WebAssembly.Table`
-   * matching the declared shape. Returns whichever values the import
-   * object should use for the `env` namespace; either may be undefined
-   * (e.g. preview1-style binaries that export their own memory).
+   * Convert the parsed `env.*` import descriptors into concrete
+   * `WebAssembly.Memory` / `WebAssembly.Table` instances, honouring any
+   * host overrides on the context. Either result may be undefined when
+   * the binary doesn't import the corresponding entry (preview1-style
+   * binaries that export their own memory, for example).
    */
-  resolveEnvImports(module: WebAssembly.Module): {
+  resolveEnvImports(descriptors: ParsedEnvImports): {
     memory?: WebAssembly.Memory;
     indirectFunctionTable?: WebAssembly.Table;
   } {
     let memory: WebAssembly.Memory | undefined;
     let indirectFunctionTable: WebAssembly.Table | undefined;
 
-    for (const entry of WebAssembly.Module.imports(module)) {
-      if (entry.module !== "env") continue;
-
-      if (entry.kind === "memory" && entry.name === "memory") {
-        // The import descriptor (`MemoryDescriptor`) is exposed on the
-        // entry across browsers as the bag of `initial`/`maximum`/`shared`
-        // fields. Type definitions don't surface it yet, so cast.
-        const descriptor = (
-          entry as unknown as { type?: WebAssembly.MemoryDescriptor }
-        ).type;
-        const initial = descriptor?.initial ?? 0;
-        const maximum = descriptor?.maximum;
-        const shared =
-          (descriptor as { shared?: boolean } | undefined)?.shared ?? false;
-
-        const override = this.context.memory;
-        if (override) {
-          validateMemoryOverride(override, { initial, maximum, shared });
-          memory = override;
-        } else {
-          memory = new WebAssembly.Memory({
-            initial,
-            ...(maximum !== undefined ? { maximum } : {}),
-            ...(shared ? { shared: true } : {}),
-          } as WebAssembly.MemoryDescriptor);
-        }
-        continue;
+    if (descriptors.memory) {
+      const { initial, maximum, shared } = descriptors.memory;
+      const override = this.context.memory;
+      if (override) {
+        validateMemoryOverride(override, { initial, maximum, shared });
+        memory = override;
+      } else {
+        memory = new WebAssembly.Memory({
+          initial,
+          ...(maximum !== undefined ? { maximum } : {}),
+          ...(shared ? { shared: true } : {}),
+        } as WebAssembly.MemoryDescriptor);
       }
+    }
 
-      if (
-        entry.kind === "table" &&
-        entry.name === "__indirect_function_table"
-      ) {
-        const descriptor = (
-          entry as unknown as { type?: WebAssembly.TableDescriptor }
-        ).type;
-        const element = (descriptor?.element ?? "funcref") as
-          | "anyfunc"
-          | "funcref"
-          | "externref";
-        const initial = descriptor?.initial ?? 0;
-        const maximum = descriptor?.maximum;
-
-        const override = this.context.indirectFunctionTable;
-        if (override) {
-          validateTableOverride(override, { element, initial, maximum });
-          indirectFunctionTable = override;
-        } else {
-          indirectFunctionTable = new WebAssembly.Table({
-            element,
-            initial,
-            ...(maximum !== undefined ? { maximum } : {}),
-          } as WebAssembly.TableDescriptor);
-        }
-        continue;
+    if (descriptors.table) {
+      const { element, initial, maximum } = descriptors.table;
+      const override = this.context.indirectFunctionTable;
+      if (override) {
+        validateTableOverride(override, { element, initial, maximum });
+        indirectFunctionTable = override;
+      } else {
+        indirectFunctionTable = new WebAssembly.Table({
+          element,
+          initial,
+          ...(maximum !== undefined ? { maximum } : {}),
+        } as WebAssembly.TableDescriptor);
       }
     }
 
@@ -541,6 +527,43 @@ export class WASIX {
     }
   }
 
+  // path_open2 is the wasix v2 variant: same as preview1 path_open
+  // plus an extended fdflags2 word (the last i32 before retptr). The
+  // extra flag bits are not yet modelled, but ignoring them and routing
+  // through the existing pathOpen unblocks every wasix-libc binary
+  // that calls open()/opendir() — those use path_open2 unconditionally.
+  // TODO(slice-9): honour fdflags2 once the fd-table extraction surfaces
+  //   semantics for the new bits (close-on-exec etc.).
+  private wasix_path_open2(
+    fdDir: number,
+    dirflags: number,
+    pathPtr: number,
+    pathLen: number,
+    oflags: number,
+    rightsBase: bigint,
+    rightsInheriting: bigint,
+    fdflags: number,
+    _fdflags2: number,
+    retptr: number,
+  ): number {
+    try {
+      const path = readString(this.memory, pathPtr, pathLen);
+      const newFd = this.fs.pathOpen(
+        fdDir,
+        dirflags,
+        path,
+        oflags,
+        rightsBase,
+        rightsInheriting,
+        fdflags,
+      );
+      new DataView(this.memory.buffer).setUint32(retptr, newFd, true);
+      return Result.SUCCESS;
+    } catch (e) {
+      return mapError(e, this.context.debug, "path_open2");
+    }
+  }
+
   private wasix_path_filestat_get(
     fdDir: number,
     dirflags: number,
@@ -679,10 +702,7 @@ export class WASIX {
       path_filestat_set_times: enosys,
       path_link: enosys,
       path_open: this.wasix_path_open.bind(this),
-      // TODO(slice-9): path_open2 carries an extended fdflags arg; for now
-      // it returns ENOSYS so binaries that link both v1 and v2 can still
-      // instantiate, since the v1 path_open is already wired.
-      path_open2: enosys,
+      path_open2: this.wasix_path_open2.bind(this),
       path_readlink: enosys,
       path_remove_directory: this.wasix_path_remove_directory.bind(this),
       path_rename: this.wasix_path_rename.bind(this),
@@ -698,8 +718,17 @@ export class WASIX {
       proc_exec3: enosys, // TODO(slice-7): proc/exec provider
       proc_join: enosys,
       proc_signal: enosys,
-      proc_signals_get: enosys, // TODO(slice-8): signals provider
-      proc_signals_sizes_get: enosys, // TODO(slice-8): signals provider
+      // proc_signals_get / _sizes_get land with the signals provider in
+      // Slice 8. Until then we report "zero registered signals" instead
+      // of ENOSYS — wasix-libc's startup path treats ENOSYS as a fatal
+      // init error and exits with 71 before reaching `main`, but a
+      // size-0 signals table is the well-formed "no signals" answer
+      // that lets early init complete.
+      proc_signals_get: () => Result.SUCCESS,
+      proc_signals_sizes_get: (sizePtr: number) => {
+        new DataView(this.memory.buffer).setUint32(sizePtr, 0, true);
+        return Result.SUCCESS;
+      },
       proc_raise: enosys,
       proc_spawn: enosys,
       proc_spawn2: enosys, // TODO(slice-7): proc/spawn provider
@@ -806,6 +835,188 @@ export class WASIX {
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
+/**
+ * Descriptor info for the two `env.*` imports that drive WASIX module
+ * instantiation. Either field is absent when the binary doesn't import
+ * the corresponding entity.
+ */
+type ParsedEnvImports = {
+  memory?: { initial: number; maximum?: number; shared: boolean };
+  table?: {
+    element: "funcref" | "externref";
+    initial: number;
+    maximum?: number;
+  };
+};
+
+/**
+ * Walk the wasm import section just far enough to extract the descriptor
+ * for `env.memory` and `env.__indirect_function_table`. The standard
+ * `WebAssembly.Module.imports()` API only returns `{ module, name, kind }`
+ * — limits and the shared flag are not exposed — so we read them out of
+ * the binary directly. Returns descriptors for whichever of the two are
+ * present; missing entries map to undefined fields.
+ *
+ * The parser only descends into section id 2 (Imports) and stops as soon
+ * as the imports run out. It tolerates unknown leading custom sections.
+ *
+ * Wasm binary layout (relevant subset):
+ *   magic+version (8 bytes), then a sequence of sections:
+ *     section: id:byte, size:varuint32, content:bytes[size]
+ *   Imports section content:
+ *     count:varuint32, entries:Import[count]
+ *   Import:
+ *     module:vec<u8>, name:vec<u8>, kind:byte, descriptor
+ *   Memory descriptor (kind=2):
+ *     limits-flag:byte (bit0=has_max, bit1=shared, bit2=memory64)
+ *     min:varuint32 (or varuint64 if memory64)
+ *     max:varuint32 (or varuint64) if has_max
+ *   Table descriptor (kind=1):
+ *     elem-type:byte (0x70=funcref, 0x6f=externref)
+ *     limits-flag:byte (bit0=has_max), then min, then max if has_max
+ */
+function parseEnvImportDescriptors(bytes: Uint8Array): ParsedEnvImports {
+  const out: ParsedEnvImports = {};
+
+  // Magic 0x00 0x61 0x73 0x6d ('\0asm') and version 1.
+  if (bytes.length < 8) return out;
+  if (
+    bytes[0] !== 0x00 ||
+    bytes[1] !== 0x61 ||
+    bytes[2] !== 0x73 ||
+    bytes[3] !== 0x6d
+  ) {
+    return out;
+  }
+
+  let offset = 8;
+  const decoder = new TextDecoder();
+
+  while (offset < bytes.length) {
+    const sectionId = bytes[offset++];
+    const [sectionSize, sizeOffset] = readVarUint32(bytes, offset);
+    offset = sizeOffset;
+    const sectionEnd = offset + sectionSize;
+
+    if (sectionId !== 2) {
+      offset = sectionEnd;
+      continue;
+    }
+
+    const [importCount, countOffset] = readVarUint32(bytes, offset);
+    offset = countOffset;
+
+    for (let i = 0; i < importCount; i++) {
+      const [modLen, modLenEnd] = readVarUint32(bytes, offset);
+      offset = modLenEnd;
+      const modName = decoder.decode(bytes.subarray(offset, offset + modLen));
+      offset += modLen;
+
+      const [nmLen, nmLenEnd] = readVarUint32(bytes, offset);
+      offset = nmLenEnd;
+      const importName = decoder.decode(bytes.subarray(offset, offset + nmLen));
+      offset += nmLen;
+
+      const kind = bytes[offset++];
+
+      // 0=function, 1=table, 2=memory, 3=global. We only care about
+      // env.memory and env.__indirect_function_table; everything else
+      // gets skipped past by reading just enough of its descriptor to
+      // advance the cursor.
+      if (kind === 0) {
+        // function: typeidx
+        const [, end] = readVarUint32(bytes, offset);
+        offset = end;
+      } else if (kind === 1) {
+        // table: reftype + limits
+        const elemTypeByte = bytes[offset++];
+        const flags = bytes[offset++];
+        const [initial, afterInitial] = readVarUint32(bytes, offset);
+        offset = afterInitial;
+        let maximum: number | undefined;
+        if (flags & 0x01) {
+          const [max, afterMax] = readVarUint32(bytes, offset);
+          maximum = max;
+          offset = afterMax;
+        }
+        if (modName === "env" && importName === "__indirect_function_table") {
+          const element = elemTypeByte === 0x6f ? "externref" : "funcref";
+          out.table = { element, initial, maximum };
+        }
+      } else if (kind === 2) {
+        // memory: limits with shared bit
+        const flags = bytes[offset++];
+        const isMemory64 = (flags & 0x04) !== 0;
+        const [initial, afterInitial] = isMemory64
+          ? readVarUint64AsNumber(bytes, offset)
+          : readVarUint32(bytes, offset);
+        offset = afterInitial;
+        let maximum: number | undefined;
+        if (flags & 0x01) {
+          const [max, afterMax] = isMemory64
+            ? readVarUint64AsNumber(bytes, offset)
+            : readVarUint32(bytes, offset);
+          maximum = max;
+          offset = afterMax;
+        }
+        if (modName === "env" && importName === "memory") {
+          out.memory = {
+            initial,
+            maximum,
+            shared: (flags & 0x02) !== 0,
+          };
+        }
+      } else if (kind === 3) {
+        // global: valtype + mutability
+        offset += 2;
+      } else {
+        // Unknown kind — bail to be safe rather than misalign the parse.
+        return out;
+      }
+    }
+
+    return out;
+  }
+
+  return out;
+}
+
+function readVarUint32(bytes: Uint8Array, offset: number): [number, number] {
+  let result = 0;
+  let shift = 0;
+  while (true) {
+    const b = bytes[offset++];
+    result |= (b & 0x7f) << shift;
+    if ((b & 0x80) === 0) break;
+    shift += 7;
+    if (shift > 35) {
+      throw new Error("WASIX: malformed varuint32 in module import section");
+    }
+  }
+  return [result >>> 0, offset];
+}
+
+function readVarUint64AsNumber(
+  bytes: Uint8Array,
+  offset: number,
+): [number, number] {
+  let result = 0n;
+  let shift = 0n;
+  while (true) {
+    const b = bytes[offset++];
+    result |= BigInt(b & 0x7f) << shift;
+    if ((b & 0x80) === 0) break;
+    shift += 7n;
+    if (shift > 70n) {
+      throw new Error("WASIX: malformed varuint64 in module import section");
+    }
+  }
+  if (result > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error("WASIX: memory64 limit exceeds Number.MAX_SAFE_INTEGER");
+  }
+  return [Number(result), offset];
+}
+
 function validateMemoryOverride(
   memory: WebAssembly.Memory,
   descriptor: { initial: number; maximum?: number; shared: boolean },
@@ -855,7 +1066,12 @@ function readString(
   ptr: number,
   len: number,
 ): string {
-  return new TextDecoder().decode(new Uint8Array(memory.buffer, ptr, len));
+  // Copy out before decoding: when env.memory is a SharedArrayBuffer
+  // (the threaded wasix-libc default) TextDecoder rejects views over it.
+  // `slice` returns a Uint8Array backed by a fresh non-shared ArrayBuffer.
+  return new TextDecoder().decode(
+    new Uint8Array(memory.buffer, ptr, len).slice(),
+  );
 }
 
 function readIOVectors(

--- a/packages/wasi/lib/wasix/wasix.ts
+++ b/packages/wasi/lib/wasix/wasix.ts
@@ -67,6 +67,13 @@ export class WASIX {
   private _random?: RandomProvider;
 
   /**
+   * Current working directory as an absolute, normalised path. Mutated
+   * by `chdir`, read by `getcwd`. Default `/home` mirrors wasix-libc's
+   * compiled-in default (the wasmer runner mounts the test dir there).
+   */
+  private cwd: string = "/home";
+
+  /**
    * Start a WASIX command.
    *
    * Buffers the module bytes so we can parse the import section
@@ -202,10 +209,21 @@ export class WASIX {
     if (env.indirectFunctionTable)
       envImports.__indirect_function_table = env.indirectFunctionTable;
 
+    // wasix-libc binaries discover preopens via preview1's
+    // `fd_prestat_get` / `fd_prestat_dir_name`, not the wasix_32v1
+    // surface. Override the preview1 entries so the FS provider's
+    // preopen map (e.g. fd 4 = "/home") is visible to the libc startup
+    // walk; otherwise it stops after fd 3 and never finds /home.
+    const preview1Overrides = {
+      ...preview1,
+      proc_exit: procExit,
+      fd_prestat_get: this.wasix_fd_prestat_get.bind(this),
+      fd_prestat_dir_name: this.wasix_fd_prestat_dir_name.bind(this),
+    };
     return {
       env: envImports,
       wasix_32v1: this.getWasix32v1Imports(),
-      wasi_snapshot_preview1: { ...preview1, proc_exit: procExit },
+      wasi_snapshot_preview1: preview1Overrides,
       wasi_unstable: { ...unstable, proc_exit: procExit },
     };
   }
@@ -624,6 +642,115 @@ export class WASIX {
     }
   }
 
+  //
+  // Working directory — getcwd / chdir. wasix-libc binaries call these
+  // directly; preview1 has no cwd surface. wasix-libc's `__wasilibc_resolve_path`
+  // reads getcwd to turn relative paths absolute before walking the
+  // preopen table, so the cwd lives entirely as runtime state — there is
+  // no per-syscall cwd-relative resolution further down the path stack.
+  //
+  // ABI:
+  //   getcwd(path_buf: *mut u8, path_buf_len: *mut u32) -> errno
+  //     - On entry, *path_buf_len is the buffer's capacity.
+  //     - On exit, *path_buf_len is set to the cwd's byte length and
+  //       up to that many bytes are copied into path_buf. EOVERFLOW is
+  //       returned (and the length is still written) when the buffer is
+  //       too small, mirroring upstream wasmer behaviour so callers can
+  //       grow the buffer and retry.
+  //   chdir(path: *const u8, path_len: u32) -> errno
+  //     - The string is treated as either absolute or relative-to-cwd
+  //       and validated by checking that the resolved path lives under
+  //       a known preopen and resolves to a directory in the FS provider.
+  //
+
+  private wasix_getcwd(pathBufPtr: number, pathLenPtr: number): number {
+    try {
+      const view = new DataView(this.memory.buffer);
+      const maxLen = view.getUint32(pathLenPtr, true);
+      const bytes = new TextEncoder().encode(this.cwd);
+      // Always write the actual length first — upstream wasmer does the
+      // same so callers can retry with a larger buffer after EOVERFLOW.
+      view.setUint32(pathLenPtr, bytes.byteLength, true);
+      if (bytes.byteLength > maxLen) {
+        return Result.EOVERFLOW;
+      }
+      new Uint8Array(this.memory.buffer, pathBufPtr, bytes.byteLength).set(
+        bytes,
+      );
+      return Result.SUCCESS;
+    } catch (e) {
+      return mapError(e, this.context.debug, "getcwd");
+    }
+  }
+
+  private wasix_chdir(pathPtr: number, pathLen: number): number {
+    try {
+      const path = readString(this.memory, pathPtr, pathLen);
+      const resolved = resolveAbsolute(this.cwd, path);
+      const match = this.findPreopenFor(resolved);
+      if (match === null) {
+        return Result.ENOENT;
+      }
+      // The preopen root itself is always a directory; only validate
+      // when there's a non-trivial relative component to look up.
+      if (match.relativePath !== "" && match.relativePath !== ".") {
+        const stat = this.fs.pathFilestatGet(match.fd, 0, match.relativePath);
+        if (stat.filetype !== FileType.DIRECTORY) {
+          return Result.ENOTDIR;
+        }
+      }
+      this.cwd = resolved;
+      return Result.SUCCESS;
+    } catch (e) {
+      return mapError(e, this.context.debug, "chdir");
+    }
+  }
+
+  /**
+   * Find which preopen owns an absolute path. Iterates fds starting at
+   * 3 until `fdPrestatGet` returns null, picking the longest matching
+   * preopen name so nested mounts (e.g. "/home" vs "/") resolve to the
+   * more specific fd. The "." preopen is treated as the implicit root
+   * — it matches every absolute path but loses to any named match.
+   */
+  private findPreopenFor(
+    absPath: string,
+  ): { fd: number; relativePath: string } | null {
+    let best: { fd: number; relativePath: string; nameLen: number } | null =
+      null;
+    for (let fd = 3; fd < 256; fd++) {
+      const info = this.fs.fdPrestatGet(fd);
+      if (info === null) break;
+      const name = info.name;
+      if (name === "." || name === "/") {
+        if (best === null) {
+          best = {
+            fd,
+            relativePath: stripLeadingSlash(absPath),
+            nameLen: 0,
+          };
+        }
+        continue;
+      }
+      if (absPath === name) {
+        if (best === null || best.nameLen < name.length) {
+          best = { fd, relativePath: ".", nameLen: name.length };
+        }
+        continue;
+      }
+      if (absPath.startsWith(name + "/")) {
+        if (best === null || best.nameLen < name.length) {
+          best = {
+            fd,
+            relativePath: absPath.slice(name.length + 1),
+            nameLen: name.length,
+          };
+        }
+      }
+    }
+    return best;
+  }
+
   private wasix_path_rename(
     oldFd: number,
     oldPathPtr: number,
@@ -788,8 +915,8 @@ export class WASIX {
       tty_set: enosys,
 
       // Working directory
-      getcwd: enosys,
-      chdir: enosys,
+      getcwd: this.wasix_getcwd.bind(this),
+      chdir: this.wasix_chdir.bind(this),
 
       // Poll
       poll_oneoff: enosys,
@@ -1059,6 +1186,37 @@ function validateTableOverride(
   // mismatch at instantiation time. Maximum likewise.
   void descriptor.element;
   void descriptor.maximum;
+}
+
+/**
+ * Resolve a guest-supplied path against the current working directory.
+ * Absolute paths (leading `/`) bypass the cwd join. The result is
+ * normalised so `..` segments fold correctly and trailing slashes are
+ * dropped (except for the root).
+ *
+ * Used by `chdir` to compute the absolute target of a relative cwd
+ * change. Other syscalls do not call this — wasix-libc resolves
+ * relative paths against `getcwd()` itself before calling `path_*`,
+ * so by the time a path reaches the runtime it is already preopen-
+ * relative.
+ */
+function resolveAbsolute(cwd: string, path: string): string {
+  const joined = path.startsWith("/") ? path : `${cwd}/${path}`;
+  const segments = joined.split("/");
+  const out: string[] = [];
+  for (const segment of segments) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") {
+      if (out.length > 0) out.pop();
+      continue;
+    }
+    out.push(segment);
+  }
+  return "/" + out.join("/");
+}
+
+function stripLeadingSlash(path: string): string {
+  return path.startsWith("/") ? path.slice(1) : path;
 }
 
 function readString(

--- a/packages/wasi/tests/wasix-fs-provider.spec.ts
+++ b/packages/wasi/tests/wasix-fs-provider.spec.ts
@@ -61,11 +61,12 @@ test("WASIDriveFileSystemProvider: mkdir foo then rmdir foo round-trips on an em
   expect(result.createError).toBe(null);
   expect(result.removeError).toBe(null);
   expect(result.removeResult).toBe(null);
-  // Confirm the directory really is gone — pathStat over a missing path
-  // surfaces ENOTCAPABLE === 76 from the underlying WASIDrive (which
-  // doesn't distinguish "path absent" from "path not allowed"). Pinning
-  // 76 here is fine; this test guards the wrapper, not the drive.
-  expect(result.postStatResult).toBe(76);
+  // Confirm the directory really is gone — pathStat over a missing
+  // path surfaces ENOENT === 44 from the underlying WASIDrive. (The
+  // drive used to return ENOTCAPABLE for both "not allowed" and "not
+  // present", which leaked WASI's capability vocabulary into errno
+  // paths that POSIX consumers expect to see ENOENT.)
+  expect(result.postStatResult).toBe(44);
 });
 
 test("WASIDriveFileSystemProvider: rmdir on a non-empty directory still returns ENOTEMPTY", async ({

--- a/packages/wasi/tests/wasix-suite.skip.ts
+++ b/packages/wasi/tests/wasix-suite.skip.ts
@@ -64,35 +64,48 @@ export type SkipEntry = {
  *     stubbed ENOSYS at the WASIX layer pending the fd-table extraction
  *     (`requires-future-feature`).
  */
-// wasix-libc binaries call getcwd / chdir at startup and the wasmer test
-// runner mounts the test dir at /home (wasix-libc's default cwd). Slice
-// 3.5 stops at the instantiation surface — it does not implement getcwd /
-// chdir or the /home preopen plumbing — so every FS-category test that
-// expects cwd-relative resolution fails at the first stat / mkdir even
-// though the binary instantiates and reaches main. These all unblock
-// once a cwd / chdir provider lands and the test harness mounts /home;
-// the work is naturally adjacent to the threads / proc slices.
-const REQUIRES_CWD_PLUMBING: SkipEntry = {
+// The remaining FS-category carve-outs hit drive-level limitations that
+// surface only once cwd plumbing lets the binary actually exercise the
+// flat-path WASIDrive (Slice 3.5 added getcwd / chdir / /home preopen,
+// which unblocked the rest of the wasmer cwd tests). The drive will be
+// extracted and grown in a follow-up; until then these stay carved out
+// with the underlying root-cause noted, not the cwd label they used to
+// share.
+const REQUIRES_DRIVE_PATH_NORMALIZATION: SkipEntry = {
   reason: "requires-future-feature",
   note:
-    "needs cwd / chdir / getcwd providers and /home preopen mount " +
-    "(wasix-libc default cwd is /home; wasmer runner mounts the test " +
-    "dir there).",
+    "WASIDrive's flat-path map does not normalise `./` / `/./` segments. " +
+    'wasmer\'s mkdirat(cwd_fd, "./testN") writes /home/./testN/.runno, ' +
+    'which subsequent stat("testN") cannot find. Lifts with the drive ' +
+    "extraction in a later slice.",
 };
 
 export const WASIX_SUITE_SKIPS: Record<string, SkipEntry> = {
-  // ── Slice 3.5 cwd-plumbing carve-outs ─────────────────────────────
-  // Buildable, instantiate cleanly under the new env-import surface,
-  // but the test logic depends on cwd / chdir / /home preopen.
-  "closing-pre-opened-dirs": REQUIRES_CWD_PLUMBING,
-  "create-and-remove-dirs": REQUIRES_CWD_PLUMBING,
-  "create-dir-at-cwd": REQUIRES_CWD_PLUMBING,
-  "create-dir-at-cwd-with-chdir": REQUIRES_CWD_PLUMBING,
-  "cross-fs-rename": REQUIRES_CWD_PLUMBING,
-  "cwd-to-home": REQUIRES_CWD_PLUMBING,
-  "distinct-inodes-same-basename": REQUIRES_CWD_PLUMBING,
-  "fstatat-with-chdir": REQUIRES_CWD_PLUMBING,
-  "open-under-file": REQUIRES_CWD_PLUMBING,
+  // ── Drive-level limitations exposed by cwd plumbing ───────────────
+  "create-dir-at-cwd": REQUIRES_DRIVE_PATH_NORMALIZATION,
+  "create-dir-at-cwd-with-chdir": REQUIRES_DRIVE_PATH_NORMALIZATION,
+  "create-and-remove-dirs": {
+    reason: "requires-future-feature",
+    note:
+      "WASIDrive does not enforce `parent dir must exist` on mkdir — " +
+      'mkdir("test1/test2") succeeds before mkdir("test1"), so the ' +
+      "test fails its first negative assertion. Drive-level fix.",
+  },
+  "closing-pre-opened-dirs": {
+    reason: "requires-future-feature",
+    note:
+      'test closes preopen fds 3-5 then calls opendir("."); wasmer keeps ' +
+      "the cwd preopen accessible via libc-cached state across close, but " +
+      "Runno's drive drops the fd entry on close so the subsequent open " +
+      "fails. Needs the wasmer-style libc preopen retention.",
+  },
+  "open-under-file": {
+    reason: "requires-future-feature",
+    note:
+      'open("parent/child") when `parent` is a regular file should ' +
+      "return ENOTDIR; WASIDrive happily creates the deeper path because " +
+      "the flat-path map does not validate parent type. Drive-level fix.",
+  },
   "pwrite-and-size": {
     reason: "requires-future-feature",
     note:

--- a/packages/wasi/tests/wasix-suite.skip.ts
+++ b/packages/wasi/tests/wasix-suite.skip.ts
@@ -64,59 +64,42 @@ export type SkipEntry = {
  *     stubbed ENOSYS at the WASIX layer pending the fd-table extraction
  *     (`requires-future-feature`).
  */
-// Tests that wasixcc compiles and links cleanly under the current
-// toolchain but cannot yet instantiate at runtime. Every wasix-libc
-// binary imports symbols from the `env` namespace (shared memory,
-// indirect function table, pthread helpers); the WASIX runtime does
-// not provide an `env` import object yet, so `WebAssembly.instantiate`
-// rejects every guest before its `_start` is reached.
-//
-// Listing the buildable filesystem-category tests here keeps them
-// inside the harness — Playwright still reports them under
-// `wasix-skip:requires-future-feature` — without making CI red on
-// runtime failures that aren't owned by this filesystem-provider
-// change.
-const ENV_IMPORTS_NOTE =
-  "wasix-libc binary imports from the `env` namespace (shared memory, " +
-  "indirect function table, pthread helpers); WASIX runtime needs to " +
-  "provide the env import surface before any wasix-suite test can " +
-  "instantiate.";
-const ENV_IMPORTS_SKIP: SkipEntry = {
+// wasix-libc binaries call getcwd / chdir at startup and the wasmer test
+// runner mounts the test dir at /home (wasix-libc's default cwd). Slice
+// 3.5 stops at the instantiation surface — it does not implement getcwd /
+// chdir or the /home preopen plumbing — so every FS-category test that
+// expects cwd-relative resolution fails at the first stat / mkdir even
+// though the binary instantiates and reaches main. These all unblock
+// once a cwd / chdir provider lands and the test harness mounts /home;
+// the work is naturally adjacent to the threads / proc slices.
+const REQUIRES_CWD_PLUMBING: SkipEntry = {
   reason: "requires-future-feature",
-  note: ENV_IMPORTS_NOTE,
+  note:
+    "needs cwd / chdir / getcwd providers and /home preopen mount " +
+    "(wasix-libc default cwd is /home; wasmer runner mounts the test " +
+    "dir there).",
 };
-const ENV_IMPORTS_BUILT_TESTS = [
-  "closing-pre-opened-dirs",
-  "create-and-remove-dirs",
-  "create-dir-at-cwd",
-  "create-dir-at-cwd-with-chdir",
-  "cross-fs-rename",
-  "cwd-to-home",
-  "distinct-inodes-same-basename",
-  "fd-close",
-  "fs-mount",
-  "fstatat-with-chdir",
-  "mount-tmp-locally",
-  "msync-end-of-file",
-  "msync-middle-of-file",
-  "msync-start-of-file",
-  "munmap-sync-end-of-file",
-  "munmap-sync-middle-of-file",
-  "munmap-sync-start-of-file",
-  "open-under-file",
-  "popen",
-  "posix_spawn",
-  "pwrite-and-size",
-  "read-after-munmap",
-  "symlink-open-read-write",
-  "udp",
-  "vfork",
-];
 
 export const WASIX_SUITE_SKIPS: Record<string, SkipEntry> = {
-  ...Object.fromEntries(
-    ENV_IMPORTS_BUILT_TESTS.map((name) => [name, ENV_IMPORTS_SKIP]),
-  ),
+  // ── Slice 3.5 cwd-plumbing carve-outs ─────────────────────────────
+  // Buildable, instantiate cleanly under the new env-import surface,
+  // but the test logic depends on cwd / chdir / /home preopen.
+  "closing-pre-opened-dirs": REQUIRES_CWD_PLUMBING,
+  "create-and-remove-dirs": REQUIRES_CWD_PLUMBING,
+  "create-dir-at-cwd": REQUIRES_CWD_PLUMBING,
+  "create-dir-at-cwd-with-chdir": REQUIRES_CWD_PLUMBING,
+  "cross-fs-rename": REQUIRES_CWD_PLUMBING,
+  "cwd-to-home": REQUIRES_CWD_PLUMBING,
+  "distinct-inodes-same-basename": REQUIRES_CWD_PLUMBING,
+  "fstatat-with-chdir": REQUIRES_CWD_PLUMBING,
+  "open-under-file": REQUIRES_CWD_PLUMBING,
+  "pwrite-and-size": {
+    reason: "requires-future-feature",
+    note:
+      "needs --volume=.:/data preopen mount (the test opens absolute " +
+      "/data/my_file.txt). Single-preopen WASIDrive can't model the " +
+      "wasmer multi-mount layout yet.",
+  },
   "close-preopen": {
     reason: "requires-future-feature",
     note:
@@ -128,6 +111,71 @@ export const WASIX_SUITE_SKIPS: Record<string, SkipEntry> = {
     note:
       "dup2 = fd_renumber, deliberately stubbed ENOSYS — fd-table mgmt " +
       "is co-located with WASIDrive and will lift later.",
+  },
+  "fd-close": {
+    reason: "requires-provider-sockets",
+    note:
+      "test opens a TCP socket via socket(AF_INET, SOCK_STREAM) and " +
+      "expects close(fd) plus EBADF on second close. Needs " +
+      "SocketsProvider + /bin preopen.",
+  },
+  "fs-mount": {
+    reason: "requires-future-feature",
+    note: "mount syscall; Runno has a single preopen root.",
+  },
+  "mount-tmp-locally": {
+    reason: "requires-future-feature",
+    note: "mount syscall; Runno has a single preopen root.",
+  },
+  "msync-end-of-file": {
+    reason: "requires-future-feature",
+    note: "mmap / msync — WASIDrive doesn't model file-backed mappings.",
+  },
+  "msync-middle-of-file": {
+    reason: "requires-future-feature",
+    note: "mmap / msync — WASIDrive doesn't model file-backed mappings.",
+  },
+  "msync-start-of-file": {
+    reason: "requires-future-feature",
+    note: "mmap / msync — WASIDrive doesn't model file-backed mappings.",
+  },
+  "munmap-sync-end-of-file": {
+    reason: "requires-future-feature",
+    note: "mmap / munmap — WASIDrive doesn't model file-backed mappings.",
+  },
+  "munmap-sync-middle-of-file": {
+    reason: "requires-future-feature",
+    note: "mmap / munmap — WASIDrive doesn't model file-backed mappings.",
+  },
+  "munmap-sync-start-of-file": {
+    reason: "requires-future-feature",
+    note: "mmap / munmap — WASIDrive doesn't model file-backed mappings.",
+  },
+  popen: {
+    reason: "requires-provider-proc",
+    note: "needs proc_spawn2 + proc_join (proc provider).",
+  },
+  posix_spawn: {
+    reason: "requires-provider-proc",
+    note: "needs proc_spawn2 + proc_join (proc provider).",
+  },
+  "read-after-munmap": {
+    reason: "requires-future-feature",
+    note: "mmap / munmap — WASIDrive doesn't model file-backed mappings.",
+  },
+  "symlink-open-read-write": {
+    reason: "requires-future-feature",
+    note: "symlinks are not represented in WASIDrive.",
+  },
+  udp: {
+    reason: "requires-provider-sockets",
+    note: "raw UDP send/recv — needs SocketsProvider.",
+  },
+  vfork: {
+    reason: "requires-provider-proc",
+    note:
+      "needs proc_fork_env + proc_exec3 (proc provider). Distinct from " +
+      "POSIX vfork — wasix-libc reuses proc_fork semantics.",
   },
   epoll: {
     reason: "requires-future-feature",

--- a/packages/wasi/tests/wasix-suite.skip.ts
+++ b/packages/wasi/tests/wasix-suite.skip.ts
@@ -64,55 +64,14 @@ export type SkipEntry = {
  *     stubbed ENOSYS at the WASIX layer pending the fd-table extraction
  *     (`requires-future-feature`).
  */
-// The remaining FS-category carve-outs hit drive-level limitations that
-// surface only once cwd plumbing lets the binary actually exercise the
-// flat-path WASIDrive (Slice 3.5 added getcwd / chdir / /home preopen,
-// which unblocked the rest of the wasmer cwd tests). The drive will be
-// extracted and grown in a follow-up; until then these stay carved out
-// with the underlying root-cause noted, not the cwd label they used to
-// share.
-const REQUIRES_DRIVE_PATH_NORMALIZATION: SkipEntry = {
-  reason: "requires-future-feature",
-  note:
-    "WASIDrive's flat-path map does not normalise `./` / `/./` segments. " +
-    'wasmer\'s mkdirat(cwd_fd, "./testN") writes /home/./testN/.runno, ' +
-    'which subsequent stat("testN") cannot find. Lifts with the drive ' +
-    "extraction in a later slice.",
-};
+// Slice 3.5 closed out the FS-category carve-outs at the drive level
+// (`./` normalisation, parent-dir-exists / parent-type validation,
+// preopen retention across `close`, `.`/`..` synthesis in readdir, and
+// the harness-side mount seeding for `/tmp` and `--volume host:guest`
+// targets). The remaining entries below are non-drive gaps —
+// fd-table extraction, sockets, mmap, proc, etc.
 
 export const WASIX_SUITE_SKIPS: Record<string, SkipEntry> = {
-  // ── Drive-level limitations exposed by cwd plumbing ───────────────
-  "create-dir-at-cwd": REQUIRES_DRIVE_PATH_NORMALIZATION,
-  "create-dir-at-cwd-with-chdir": REQUIRES_DRIVE_PATH_NORMALIZATION,
-  "create-and-remove-dirs": {
-    reason: "requires-future-feature",
-    note:
-      "WASIDrive does not enforce `parent dir must exist` on mkdir — " +
-      'mkdir("test1/test2") succeeds before mkdir("test1"), so the ' +
-      "test fails its first negative assertion. Drive-level fix.",
-  },
-  "closing-pre-opened-dirs": {
-    reason: "requires-future-feature",
-    note:
-      'test closes preopen fds 3-5 then calls opendir("."); wasmer keeps ' +
-      "the cwd preopen accessible via libc-cached state across close, but " +
-      "Runno's drive drops the fd entry on close so the subsequent open " +
-      "fails. Needs the wasmer-style libc preopen retention.",
-  },
-  "open-under-file": {
-    reason: "requires-future-feature",
-    note:
-      'open("parent/child") when `parent` is a regular file should ' +
-      "return ENOTDIR; WASIDrive happily creates the deeper path because " +
-      "the flat-path map does not validate parent type. Drive-level fix.",
-  },
-  "pwrite-and-size": {
-    reason: "requires-future-feature",
-    note:
-      "needs --volume=.:/data preopen mount (the test opens absolute " +
-      "/data/my_file.txt). Single-preopen WASIDrive can't model the " +
-      "wasmer multi-mount layout yet.",
-  },
   "close-preopen": {
     reason: "requires-future-feature",
     note:

--- a/packages/wasi/tests/wasix-suite.spec.ts
+++ b/packages/wasi/tests/wasix-suite.spec.ts
@@ -15,9 +15,15 @@
 //     them at Node-time and passes them into `page.evaluate` so each
 //     test sees the right argv.
 //   - `--volume .` maps the test directory's input files (everything
-//     beyond `main.c` / `run.sh`) into the guest's preopened ".". Each
-//     test run starts with a fresh in-memory filesystem seeded from
-//     those inputs, so per-test isolation is preserved.
+//     beyond `main.c` / `run.sh`) into the guest's preopen tree. The
+//     wasmer runner mounts `--volume .` at `/home` because that's
+//     wasix-libc's compiled-in default cwd, so the harness mirrors
+//     that: inputs are seeded under `/home/<rel-path>`, the FS
+//     provider exposes `/home` as a preopen at fd 4, and `PWD` is set
+//     so libc's startup path resolver finds the cwd before calling
+//     `getcwd`.
+//   - Each test run starts with a fresh in-memory filesystem seeded
+//     from those inputs, so per-test isolation is preserved.
 
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
@@ -264,13 +270,16 @@ test.describe("wasix integration suite (wasmer/tests/wasix)", () => {
         const WC = w.WASIXContext;
         const WD = w.WASIDriveFileSystemProvider;
 
-        // Seed a fresh WASIFS for this run from the per-test inputs.
-        // Paths are rooted at `/` so they resolve through the single
-        // preopen (".") the WASIDrive exposes.
+        // Seed a fresh WASIFS under /home for this run — the wasmer
+        // runner mounts `--volume .` at /home (wasix-libc's default
+        // cwd), so per-test inputs land at /home/<rel-path>. The
+        // provider exposes /home as a preopen at fd 4 alongside the
+        // implicit fd 3 = ".", and PWD primes the libc startup
+        // resolver before it falls back to getcwd().
         const now = new Date();
         const fs: WASIFS = {};
         for (const input of p.inputs) {
-          const guestPath = `/${input.path}`;
+          const guestPath = `/home/${input.path}`;
           fs[guestPath] = {
             path: guestPath,
             timestamps: { access: now, modification: now, change: now },
@@ -286,6 +295,7 @@ test.describe("wasix integration suite (wasmer/tests/wasix)", () => {
           fetch(p.wasmUrl),
           new WC({
             args: p.args,
+            env: { PWD: "/home" },
             stdout: (out: string) => {
               stdout += out;
             },
@@ -293,7 +303,9 @@ test.describe("wasix integration suite (wasmer/tests/wasix)", () => {
               stderr += err;
             },
             stdin: () => null,
-            fs: new WD(fs),
+            fs: new WD(fs, {
+              preopens: [{ name: "/home", prefix: "/home/" }],
+            }),
           }),
         );
 

--- a/packages/wasi/tests/wasix-suite.spec.ts
+++ b/packages/wasi/tests/wasix-suite.spec.ts
@@ -50,9 +50,16 @@ const wasixTestsDir = join(
   "wasix",
 );
 
-// Files present in every wasmer test directory that are never part of
-// the preopened input mapping.
-const NON_INPUT_FILES = new Set(["main.c", "run.sh", "Makefile", "README.md"]);
+/**
+ * Files the wasmer runner produces at runtime in the test directory
+ * (the `--volume .` mount is the test source dir, into which wasmer
+ * also writes `main.wasm` and the redirected `output` capture). They
+ * are not present on disk for us to read, so the harness synthesises
+ * empty placeholders alongside the on-disk inputs. Tests that
+ * iterate the cwd listing (e.g. `closing-pre-opened-dirs`) assert
+ * against these names.
+ */
+const SYNTHESIZED_RUNTIME_FILES = ["main.wasm", "output"] as const;
 
 type TestInput = {
   /** Path inside the guest filesystem, relative to the preopen ("."). */
@@ -66,6 +73,13 @@ type TestPlan = {
   wasmUrl: string;
   args: string[];
   inputs: TestInput[];
+  /**
+   * Absolute guest paths that the wasmer runner mounts via
+   * `--volume host:guest` (e.g. `/data`, `/temp1`). The harness
+   * pre-seeds each as an empty directory so file ops under those
+   * mounts pass POSIX parent-exists checks.
+   */
+  mounts: string[];
 };
 
 function listWasmBinaries(): string[] {
@@ -94,6 +108,51 @@ function listWasmBinaries(): string[] {
  * top-level invocation of the wasmer runner.
  */
 function parseRunSh(source: string): string[] {
+  const tokens = runShTokens(source);
+  const sep = tokens.indexOf("--");
+  if (sep === -1) return [];
+  return tokens.slice(sep + 1);
+}
+
+/**
+ * Extract the absolute guest paths that the wasmer run.sh mounts via
+ * `--volume host:guest` (or `--volume=host:guest`). A bare
+ * `--volume host` (no colon) maps to wasix-libc's default cwd
+ * (`/home`) and is already handled by the input seeding, so it is
+ * skipped here.
+ *
+ * Used to pre-seed mount-point directories in the in-memory FS so
+ * `open(O_CREAT)` under those mounts passes the drive's POSIX
+ * parent-exists check (the wasmer runner provides them implicitly).
+ */
+function parseRunShVolumeMounts(source: string): string[] {
+  const tokens = runShTokens(source);
+  const stop = tokens.indexOf("--");
+  const head = stop === -1 ? tokens : tokens.slice(0, stop);
+  const targets: string[] = [];
+  for (let i = 0; i < head.length; i++) {
+    const tok = head[i];
+    let arg: string | undefined;
+    if (tok === "--volume" || tok === "--mapdir") {
+      arg = head[i + 1];
+      i++;
+    } else if (tok.startsWith("--volume=") || tok.startsWith("--mapdir=")) {
+      arg = tok.slice(tok.indexOf("=") + 1);
+    } else {
+      continue;
+    }
+    if (!arg) continue;
+    const colon = arg.indexOf(":");
+    if (colon === -1) continue;
+    const guest = arg.slice(colon + 1);
+    if (guest.startsWith("/")) {
+      targets.push(guest);
+    }
+  }
+  return targets;
+}
+
+function runShTokens(source: string): string[] {
   const body = source
     .split("\n")
     .filter((line) => !line.startsWith("#!") && !/^\s*#/.test(line))
@@ -112,10 +171,7 @@ function parseRunSh(source: string): string[] {
 
   if (!runLine) return [];
 
-  const tokens = shellSplit(runLine);
-  const sep = tokens.indexOf("--");
-  if (sep === -1) return [];
-  return tokens.slice(sep + 1);
+  return shellSplit(runLine);
 }
 
 /**
@@ -187,14 +243,20 @@ function collectInputs(dir: string): TestInput[] {
         continue;
       }
       if (!st.isFile()) continue;
-      // Skip source / metadata files at the top level. Anything nested
-      // (e.g. inputs in a `fixture/` subdir) is kept verbatim.
-      if (sub === "" && NON_INPUT_FILES.has(entry)) continue;
       const bytes = readFileSync(abs);
       out.push({ path: rel, bytes: Array.from(bytes) });
     }
   };
   walk("");
+  // Append empty placeholders for the runtime artefacts that wasmer
+  // would otherwise produce in the test directory (the binary itself
+  // and the captured `output`). Tests that iterate cwd contents
+  // assert these names, but our harness fetches the wasm separately
+  // and never produces an output file.
+  for (const synthetic of SYNTHESIZED_RUNTIME_FILES) {
+    if (out.some((existing) => existing.path === synthetic)) continue;
+    out.push({ path: synthetic, bytes: [] });
+  }
   return out;
 }
 
@@ -202,11 +264,18 @@ function planForTest(name: string): TestPlan {
   const srcDir = join(wasixTestsDir, name);
   const runShPath = join(srcDir, "run.sh");
   let args: string[] = [];
+  let mounts: string[] = [];
   if (existsSync(runShPath)) {
+    const source = readFileSync(runShPath, "utf8");
     try {
-      args = parseRunSh(readFileSync(runShPath, "utf8"));
+      args = parseRunSh(source);
     } catch {
       args = [];
+    }
+    try {
+      mounts = parseRunShVolumeMounts(source);
+    } catch {
+      mounts = [];
     }
   }
   return {
@@ -214,6 +283,7 @@ function planForTest(name: string): TestPlan {
     wasmUrl: `/bin/wasix-tests/${name}.wasm`,
     args,
     inputs: collectInputs(srcDir),
+    mounts,
   };
 }
 
@@ -285,6 +355,24 @@ test.describe("wasix integration suite (wasmer/tests/wasix)", () => {
             timestamps: { access: now, modification: now, change: now },
             mode: "binary",
             content: new Uint8Array(input.bytes),
+          };
+        }
+
+        // Pre-seed each `--volume host:guest` target plus the implicit
+        // `/tmp` MemFS mount as empty directories. The WASIDrive uses
+        // `.runno` sentinel files to model directory presence, so the
+        // mount points appear as real dirs to subsequent path ops
+        // (POSIX parent-exists checks). Mirrors what the wasmer runner
+        // provides without requiring per-test harness wiring.
+        for (const guest of ["/tmp", ...p.mounts]) {
+          const trimmed = guest.endsWith("/") ? guest.slice(0, -1) : guest;
+          if (!trimmed) continue;
+          const marker = `${trimmed}/.runno`;
+          fs[marker] = {
+            path: marker,
+            timestamps: { access: now, modification: now, change: now },
+            mode: "string",
+            content: "",
           };
         }
 

--- a/packages/wasi/vite.config.js
+++ b/packages/wasi/vite.config.js
@@ -3,13 +3,18 @@ import typescript from "@rollup/plugin-typescript";
 import { resolve } from "path";
 import { defineConfig } from "vite";
 
-// NOTE (Slice 4): WASIXWorkerHost will need COOP/COEP headers on the dev
-// server so SharedArrayBuffer/Atomics are available. Set
-// `server.headers['Cross-Origin-Opener-Policy']   = 'same-origin'` and
-// `server.headers['Cross-Origin-Embedder-Policy'] = 'require-corp'` when the
-// worker lands. Slice 1 does not exercise threads, so headers stay off here.
-
 export default defineConfig({
+  // wasix-libc binaries import a shared `env.memory`. Browsers reject
+  // SharedArrayBuffer-backed memories unless the host page is
+  // cross-origin-isolated (COOP `same-origin` + COEP `require-corp`).
+  // The Playwright suite drives the dev server via `test:server`, so the
+  // headers carry into every test run.
+  server: {
+    headers: {
+      "Cross-Origin-Opener-Policy": "same-origin",
+      "Cross-Origin-Embedder-Policy": "require-corp",
+    },
+  },
   build: {
     copyPublicDir: false, // Public dir contains testing binaries
     lib: {


### PR DESCRIPTION
Implements issue #22.

Closes #22

## Summary

Make every buildable wasmer-suite binary instantiate under the WASIX runtime so the FS-only tests can run end-to-end against the Slice 3 filesystem provider. Carve-out from Slice 6 (memory auto-detect) and Slice 4 (COOP/COEP) — neither the threads provider nor the worker host ships here.

## What landed

- **WASIX-PLAN.md sequencing note** explaining why env-import auto-detect ships ahead of the threads / futex provider work (every wasix-libc binary imports `env.memory` declared shared regardless of whether it uses threads).
- **`env.memory` / `env.__indirect_function_table` auto-detect.** `WebAssembly.Module.imports()` only exposes `{ module, name, kind }` — descriptors (limits, shared flag, table element type) are not standard, confirmed against V8 (Chrome / Node 22). Implementation walks the import section on the raw bytes (tolerates leading custom sections, varuint32 / memory64 limits, funcref / externref tables), then `WebAssembly.compile` + `instantiate`. Memory + table can be overridden via new `WASIXContextOptions.memory` / `.indirectFunctionTable`.
- **`wasix_32v1` v2 import stubs.** `fd_dup2`, `path_open2` (wired via existing `pathOpen` ignoring the v2 fdflags2 arg), `fd_fdflags_get/_set`, `proc_exit2` (throws WASIXExit, same exit semantics as proc_exit), `proc_exec3`, `proc_spawn2`, `proc_fork_env`, `proc_signals_get/_sizes_get` — names taken from `wasm-objdump` of the wasmer-suite binaries. `proc_signals_get/_sizes_get` return SUCCESS with size=0 instead of ENOSYS so wasix-libc's `_start` reaches main (ENOSYS is a fatal init error there — exits 71).
- **COOP/COEP headers** on the Vite dev server (Playwright reuses it via `test:server`).
- **One-shot `console.warn`** on WASIX construction when `crossOriginIsolated === false`. Without it, the shared-memory import failure looks like a generic engine error.
- **Inner-WASI drive sharing.** wasix-libc reaches for both `wasi_snapshot_preview1` and `wasix_32v1` filesystem imports — preopen discovery (`fd_prestat_get`) is preview1. The internal WASI now reuses the `WASIDriveFileSystemProvider`'s drive when one is supplied; opaque providers keep an empty inner drive.
- **TextDecoder shared-buffer fix** in both WASI and WASIX text-decoding paths. `TextDecoder` rejects views over a `SharedArrayBuffer`; copying via `.slice()` before decode unblocks every preview1 stdout/path decode for WASIX guests.
- **CWD plumbing.** `WASIDrive` accepts `WASIDrivePreopen[]`; harness wires `/home` at fd 4 to match `wasmer run --volume .`. `getcwd` / `chdir` bound on the wasix_32v1 surface (with `resolveAbsolute` + longest-preopen match + ENOTDIR/ENOENT shape). Preview1 `fd_prestat_get` / `_dir_name` overridden so wasix-libc's preopen walk sees fd 4.
- **Drive-level fixes** (closes the gaps Ben flagged after CWD plumbing landed): `./` normalisation, parent-component validation on `open`/`pathCreateDir`, preopen retention on close, `.` / `..` synthesis + `.runno` filtering in `fdReaddir`, preview1 path syscalls routed through the WASIX provider, ENOTCAPABLE → ENOENT mapping for WASIX callers, and harness `--volume host:guest` parsing so absolute mount points are pre-seeded.
- **Skip-map re-classification.** Drop the `ENV_IMPORTS_BUILT_TESTS` block; classify each former entry per current failure mode (full list in the commit messages). Tokens stay grep-stable for downstream slice work.

## Test status

- Slice 1/2/3 specs: 57/57 chromium pass.
- Wasix-suite (chromium / firefox / webkit): 204 pass / 45 skip. All 10 in-scope FS tests flip green; the 11th (fd-close) stays carved out as a TCP socket test (`requires-provider-sockets`).
- Remaining skips are non-FS-drive (sockets, proc, mmap, threads, fd-table, mount syscall, symlinks, TTY) — match the original issue's out-of-scope list.

## Surfaced env imports (vs the proposed list)

Inspected via `wasm-objdump -x public/bin/wasix-tests/*.wasm`:

- `env.memory` (shared, initial=129, max=65536) — ✓ matched the hypothesis.
- `env.__indirect_function_table` — **not present** in any of the 25 wasmer-suite binaries at the pinned SHA. The runtime still handles it (constructed from the descriptor when surfaced) so the surface is forward-compatible.
- v2 surface beyond the proposed `fd_dup2 / path_open2 / proc_exit2`: also `proc_signals_get`, `proc_signals_sizes_get`, `fd_fdflags_get`, `fd_fdflags_set`, `proc_exec3`, `proc_spawn2`, `proc_fork_env`. All stubbed, all mapped to TODO(slice-N) pointers.

## Test plan

- [x] `npm run test:prepare:wasix-suite` — every binary builds (25/25).
- [x] `npx tsc --noEmit` clean.
- [x] `npx playwright test tests/wasix-suite.spec.ts --project=chromium --project=firefox --project=webkit` — 204 pass / 45 skip.
- [x] `npx playwright test tests/core.spec.ts tests/libc.spec.ts tests/libstd.spec.ts tests/reactor.spec.ts tests/wasix-clock-random.spec.ts tests/wasix-fs-provider.spec.ts --project=chromium` — 57 passed.
- [ ] `args.spec.ts` / `stdio.spec.ts` / `wasix-smoke.spec.ts` need cargo-built `*.wasi.wasm` binaries; not exercised in this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
