### PR TITLE
WASIX validation & testing hardening (Slice 3.5 follow-up)

### DIFF
--- a/.github/workflows/test-on-pull-request.yml
+++ b/.github/workflows/test-on-pull-request.yml
@@ -15,8 +15,8 @@ jobs:
           node-version: "22"
       - name: Install wabt (wat2wasm)
         # `packages/wasi`'s `build:tests` step needs wat2wasm to compile
-        # the hand-written WAT smoke binaries (the wasix clock/random ones
-        # and the bridge unit-test binary) into wasm before Playwright
+        # the hand-written WAT smoke binaries (wasix-clock-random,
+        # wasix-deterministic, wasix-errno) into wasm before Playwright
         # runs.
         run: sudo apt-get update && sudo apt-get install -y wabt
       - name: Install dependencies
@@ -54,12 +54,16 @@ jobs:
           version: v0.4.3
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Probe wasixcc
+        # The suite build needs both wasixcc (C tests) and wasix++
+        # (C++ tests: exception, setjmp-longjmp).
         run: |
           set -euxo pipefail
-          if ! command -v wasixcc >/dev/null 2>&1; then
-            echo "::error::wasixcc not on PATH after install."
-            exit 1
-          fi
+          for tool in wasixcc wasix++; do
+            if ! command -v "$tool" >/dev/null 2>&1; then
+              echo "::error::$tool not on PATH after install."
+              exit 1
+            fi
+          done
           wasixcc --version || true
       - name: Fetch + build wasix suite binaries
         working-directory: packages/wasi

--- a/packages/wasi/WASIX-PLAN.md
+++ b/packages/wasi/WASIX-PLAN.md
@@ -1,6 +1,10 @@
 # WASIX support — technical design
 
-_Status: design phase. Describes the target architecture; revise as decisions land._
+_Status: implementation in progress. Slices 1–3.5 have landed (skeleton,
+clock/random providers, filesystem provider, module-instantiation
+surface). This document describes the target architecture plus the
+current validation reality; see [Slice roadmap](#slice-roadmap) for
+what's built and what's next._
 
 ## Goal
 
@@ -22,10 +26,14 @@ All of that is a host-side decision; the runtime is unaware.
   (they import both).
 - Clock and Random become overridable providers (enables deterministic
   execution).
-- **Pass the upstream WASIX integration test suite
-  ([`wasmerio/wasix-integration-tests`](https://github.com/wasmerio/wasix-integration-tests))**
-  using the simulation providers shipped with the package. See
-  [Validation](#validation).
+- **Pass the upstream WASIX C test suite (`wasmer/tests/wasix` in the
+  [wasmer repo](https://github.com/wasmerio/wasmer), vendored at a
+  pinned SHA)** using the simulation providers shipped with the
+  package. See [Validation](#validation). (An earlier revision named
+  `wasmerio/wasix-integration-tests` as the bar; that repo is a
+  Rust/snapshot-based suite and is NOT what the harness runs — it
+  remains a candidate source of extra coverage, see
+  [Coverage gaps](#coverage-gaps-in-the-upstream-suite).)
 
 Every WASIX syscall has a provider slot. Unwired slots return `ENOSYS`.
 
@@ -33,12 +41,22 @@ Every WASIX syscall has a provider slot. Unwired slots return `ENOSYS`.
 
 - Tests requiring Asyncify (or JSPI) instrumentation on the guest module —
   principally `proc_fork` asserting on post-fork execution, asynchronously
-  delivered signals that pre-empt running code, and cross-frame
-  `setjmp`/`longjmp` across a JS-imported call. These need the guest's call
-  stack and program counter reified from outside, which WebAssembly does not
-  expose to JS. A provider can't supply that at call time. Tracked as
-  known-skipped. See [Future: Asyncify opt-in](#future-asyncify-opt-in) for
-  the path to lifting this.
+  delivered signals that pre-empt running code, and userspace context
+  switching (`context_create` / `context_switch`). These need the guest's
+  call stack and program counter reified from outside, which WebAssembly
+  does not expose to JS. A provider can't supply that at call time.
+  Tracked as known-skipped. See
+  [Future: Asyncify opt-in](#future-asyncify-opt-in) for the path to
+  lifting this.
+
+  _Empirical amendment (2026-07):_ cross-frame `setjmp`/`longjmp` was
+  originally in this category, but binaries built with wasm-exceptions
+  (`wasixcc`'s exnref EH build, the upstream default for C++) implement
+  `setjmp`/`longjmp` on top of wasm EH — the upstream `setjmp-longjmp`
+  and `exception` tests **pass in all three browsers today** with no
+  Asyncify. Only the asyncify-build variants of those semantics remain
+  out of reach.
+
 - `proc_exec` and `proc_spawn` are **not** in this category — they start a
   fresh instance, which a provider can do. Expected to pass.
 - Real socket / process / thread implementations baked into the runtime _or_
@@ -84,11 +102,17 @@ export type {
 
 // Ergonomic providers — concrete classes hosts can drop in
 export {
-  HTTPProvider, // AsyncSocketsProvider (Fetch-style) — worker-only
-  FileSystemProvider, // wraps WASIDrive; sync + async variants
-  ConsoleTTYProvider, // TTYProvider (sync)
-} from "./wasix/providers/ergonomic.js";
+  HTTPProvider, // AsyncSocketsProvider (Fetch-style) — worker-only (planned)
+  WASIDriveFileSystemProvider, // wraps WASIDrive (landed; the plan's
+  // earlier name `FileSystemProvider` is the raw interface it implements)
+  ConsoleTTYProvider, // TTYProvider (sync) (planned)
+} from "./wasix/providers/ergonomic/...";
 ```
+
+Landed today: `WASIX`, `WASIXContext`, the `WASIX32v1` ABI namespace,
+`SystemClockProvider` / `SystemRandomProvider` / `FixedClockProvider` /
+`SeededRandomProvider`, and `WASIDriveFileSystemProvider`. The
+worker-host surface and remaining providers are future slices.
 
 Existing `WASI`, `WASIContext`, `WASIWorkerHost`, and the
 `WASISnapshotPreview1` namespace export are unchanged. This keeps a clean slot
@@ -443,8 +467,79 @@ No provider supplied → runtime falls back to `Date.now()` and
 
 ## Validation
 
-Correctness bar: [`wasmerio/wasix-integration-tests`](https://github.com/wasmerio/wasix-integration-tests),
-the upstream WASIX integration suite.
+Correctness bar: the upstream WASIX C suite at `wasmer/tests/wasix`
+(vendored at the SHA pinned in `tests/wasix-suite.constants.ts` — 42
+test directories at the current pin).
+
+### Validation contract
+
+The harness replicates what upstream's `test.sh` + per-test `run.sh`
+actually assert — verified by audit, because exit-code-only checking is
+provably insufficient (`closing-pre-opened-dirs` passed vacuously on
+exit code alone while printing an error the upstream diff would catch):
+
+- **Build parity.** Tests build exactly as upstream does: C tests with
+  `wasixcc -sWASM_EXCEPTIONS=false` + per-test `.flags`, C++ tests with
+  `wasix++`. (`tests/build-wasix-suite.ts`.)
+- **Every run line.** Each `$WASMER_RUN main.wasm …` line in `run.sh`
+  becomes one invocation (multi-invocation tests: `udp` ×4, `vfork` ×9,
+  …), with `--volume` mounts pre-seeded and filesystem state shared
+  across invocations within a test, mirroring the host mount.
+- **Exit codes obey `set -e`.** Scripts with `set -e` require exit 0
+  from every invocation (minus upstream's own `|| true` markers).
+  Scripts without it ignore guest exit codes — `exception` exits 42 by
+  design — and validate via the stdout diff.
+- **Stdout diffs.** The `printf "…" | diff -u output -` pattern in
+  run.sh becomes a byte-equality assertion on captured stdout.
+
+### Suite partition — the denominator stays visible
+
+Every vendored test directory is classified in exactly one of:
+
+- `WASIX_INCLUDE_DIRS` — built and executed (38 of 42 today).
+- `WASIX_BUILD_EXCLUDES` — not built, with a structured reason
+  (currently only the 4 `dl-*` dynamic-linking tests, which need a
+  multi-artifact `.so` build and runtime dynamic linking).
+
+`tests/wasix-suite-consistency.spec.ts` enforces the partition, that
+every runtime-skip entry refers to a built test, and that the lists stay
+alphabetised. A wasmer SHA bump that adds upstream tests fails CI until
+the new tests are classified — coverage can't silently shrink.
+
+Runtime skips use `test.fail(...)`, not `fixme`: skipped tests still
+execute, so the moment a capability lands, stale skip entries show up as
+"passed unexpectedly" in the report. (This mechanism found
+`mount-tmp-locally` passing the same day it was wired.)
+
+### Toolchain
+
+`wasix-org/wasixcc` v0.4.3 (the latest release, pinned in CI and in
+`tests/install-wasix-tools.sh`, which installs it locally on
+macOS/Linux via the release binaries) builds **everything in the
+vendored suite except the `dl-*` family** when invoked with upstream's
+flags. The earlier belief that fork/pthread/dlopen tests "cannot link"
+was wrong — it was an artifact of our build harness not using
+`-sWASM_EXCEPTIONS=false` / `wasix++`; all fork-family tests now build
+and run (and fail as classified, awaiting Asyncify — see the skip map).
+
+### Coverage gaps in the upstream suite
+
+The vendored C suite has **no tests at all** for threads
+(`thread_spawn` / pthreads), sockets beyond `udp` + `fd-close`, TTY,
+futex, or poll/epoll. The provider slices for those surfaces therefore
+cannot lean on the wasmer suite for validation. Per-slice validation
+comes from purpose-built fixtures instead:
+
+- Hand-written WAT/C fixtures under `programs/` (the existing
+  clock/random/errno pattern), compiled with the same pinned wasixcc.
+- Candidate supplementary source:
+  [`wasmerio/wasix-integration-tests`](https://github.com/wasmerio/wasix-integration-tests)
+  (Rust, snapshot-validated) — evaluate per slice whether vendoring
+  selected tests is worth the Rust toolchain dependency.
+
+Each future slice that adds a provider MUST land with its fixtures in
+the same PR; the wasmer suite alone is not an acceptance gate for
+threads/sockets/TTY/futex work.
 
 This shapes the design in two concrete ways.
 
@@ -484,25 +579,37 @@ ship those, because Runno is a sandbox.
 
 ### Known-skipped tests
 
-**Skip rule: a test is skipped iff it requires Asyncify (or JSPI)
-instrumentation on the guest module.** No other reason justifies a skip. If
-a simulation provider can be written to make a test pass, we write one.
+**End-state skip rule: a test is skipped iff it requires Asyncify (or
+JSPI) instrumentation on the guest module, or a drive feature
+deliberately deferred to the
+[drive feature workstream](#drive-feature-workstream).** If a
+simulation provider can be written to make a test pass, we write one.
 
-In practice that rule carves out exactly three categories:
+The Asyncify category covers:
 
-- `proc_fork` asserting on post-fork guest execution.
+- `proc_fork` asserting on post-fork guest execution (all fork-family
+  tests: `fork`, `pipes`, `shared-fd`, `share-tmp-*`, `proc-exec*`,
+  `cloexec`, `signal`).
 - Asynchronous signal pre-emption — a signal delivered from outside the
   guest's current call, pre-empting running code mid-frame.
-- Cross-frame `setjmp`/`longjmp` across a JS-imported call.
+- Userspace context switching (`context_create` / `context_switch`,
+  the `context-switching` test).
 
-See [the reasoning below](#why-those-tests-cant-be-passed-by-providers-alone)
-for why these three need Asyncify. Everything else — `proc_exec`,
-`proc_spawn`, threads, futex, sockets, TTY, self-raised signals at yield
-points, clocks, random — is implementable with simulation providers and
-expected to pass.
+(Cross-frame `setjmp`/`longjmp` left this category — see the empirical
+amendment under Non-goals.)
 
-The test harness carries an explicit skip list with a one-line
-"requires-Asyncify" justification per entry.
+The drive-feature category covers mmap/msync file mappings, symlinks,
+`mount`, and stdio/fd-table close semantics — each with a matching
+entry in the workstream.
+
+**Interim rule while slices land:** tests blocked only on a provider
+that hasn't shipped yet carry a `requires-provider-*` token
+(`popen`/`posix_spawn`/`vfork` → proc, `udp`/`fd-close` → sockets).
+These flip to passing as their slice lands — enforced automatically
+because skips run as `test.fail` and report "passed unexpectedly".
+
+The skip map lives in `tests/wasix-suite.skip.ts`; every entry names a
+token from the fixed vocabulary plus a one-line justification.
 
 ### Why those tests can't be passed by providers alone
 
@@ -537,9 +644,13 @@ The same limitation hits two related syscalls:
   handler, then resume where we were" has the same resume-at-frame need.
   Self-raised signals that happen at controlled yield points are fine;
   signals delivered from outside the guest's current call are not.
-- **Cross-frame `setjmp`/`longjmp`.** Unwinding from inside a JS-imported
-  call back to a target several WASM frames up requires popping the guest
-  stack from outside. Same blocker.
+- **Userspace context switching.** `context_create` / `context_switch`
+  swap between guest execution contexts — reifying and restoring the
+  stack is the whole operation. Same blocker.
+
+(Cross-frame `setjmp`/`longjmp` used to sit here too, but wasm-exceptions
+builds implement it inside the guest via wasm EH — no external stack
+manipulation needed — and those builds pass in browsers today.)
 
 In all three, the root cause is identical: **WASM execution state is not
 reifiable from JS**.
@@ -569,10 +680,90 @@ provider capability bit. Out of scope for v1.
 
 One provider configuration — the simulation set from
 [Simulation providers ship with the package](#simulation-providers-ship-with-the-package) —
-runs in CI against both Node and browser (Playwright, COOP/COEP). Because
-the sockets provider is loopback-only and all processes live in the same JS
-realm, there is nothing environment-specific to branch on. Both runs execute
-the same suite minus the Asyncify-only skip list.
+runs in CI under Playwright against chromium, firefox, and webkit (the
+dev server sets COOP/COEP so shared-memory imports instantiate). There
+is **no Node.js runtime test target today**; `@runno/wasi` is
+browser-focused and a Node harness is possible future work, not a
+current claim. The suite runs identically in all three browsers minus
+the skip map.
+
+### Testing layers
+
+Validation is spread across five Playwright spec layers, all runnable
+locally (`npm run wasix:install-tools`, `npm run test:prepare:wasix-suite`,
+`npx playwright test`):
+
+1. **Unit** (`wasix-unit.spec.ts`, Node-side, no browser) — the wasm
+   import-section parser (`lib/wasix/module-imports.ts`), memory/table
+   override validation, cwd path resolution (`lib/wasix/path-utils.ts`).
+2. **Error model** (`wasix-error-model.spec.ts`) — a WAT probe
+   (`wasix-errno.wat`) exits with `random_get`'s errno, proving
+   `WASIXError → its errno`, `any other throw → EIO`, and that nothing
+   propagates across the WASM boundary as a JS exception.
+3. **Smoke + determinism** (`wasix-smoke`, `wasix-clock-random`,
+   `wasix-fs-provider` specs) — hand-rolled WAT guests incl. the
+   golden-byte determinism check.
+4. **preview1-under-WASIX** (`wasix-preview1-corpus.spec.ts`) — the
+   full caspervonb corpus (core/libc/libstd) run through `WASIX.start`,
+   covering the overridden preview1 delegation surface and the
+   export-memory auto-detect path. Three documented expected-failures:
+   tests asserting `errno == ENOTCAPABLE` where WASIX deliberately
+   speaks POSIX (`ENOENT`).
+5. **Upstream wasix suite** (`wasix-suite.spec.ts` +
+   `wasix-suite-consistency.spec.ts`) — as described above.
+
+## Drive feature workstream
+
+Skip-map triage surfaced drive-level capabilities (not provider slots)
+that block vendored tests. Each is deliberate deferred work with an
+owner test set, so the "skipped iff Asyncify" end-state rule stays
+honest:
+
+- **mmap / msync file-backed mappings** — 8 tests (`msync-*`,
+  `munmap-sync-*`, `read-after-munmap`). Needs the drive to model
+  memory-mapped file ranges and write-back.
+- **Symlinks** — `symlink-open-read-write`. WASIDrive has no link
+  representation. (Also needs harness-side pre-seed of `target.txt`
+  and a host-side post-assert; noted in the skip entry.)
+- **mount / multiple preopen roots** — `fs-mount`. Runno currently has
+  a single preopen root plus `/home`.
+- **fd-table extraction** — `dup` (fd_renumber/fd_dup2), stdio close
+  semantics (`closing-pre-opened-dirs` expects `fclose(stdout)` to make
+  later writes vanish; stdio currently routes to host callbacks and
+  never closes). Planned as Slice 9.
+
+## Slice roadmap
+
+Landed:
+
+1. Skeleton + hello-world smoke (`WASIX`, `WASIXContext`, wasix_32v1
+   stub surface).
+2. Clock + Random providers (+ `FixedClockProvider`,
+   `SeededRandomProvider`, golden-byte determinism test).
+3. Filesystem provider (`WASIDriveFileSystemProvider`) + wasmer suite
+   harness.
+   3.5. Module-instantiation surface (env.memory/env.\_\_indirect_function_table
+   auto-detect, COOP/COEP, v2 stubs) + validation hardening (stdout-diff
+   contract, suite partition + consistency spec, preview1-corpus-under-WASIX,
+   unit + error-model specs).
+
+Upcoming (each lands with its own fixtures per
+[Coverage gaps](#coverage-gaps-in-the-upstream-suite)):
+
+4. Sockets provider (loopback simulation) — unskips `udp`, `fd-close`;
+   needs own fixtures for TCP/accept paths.
+5. Threads provider (cooperative + real-worker helper) + shared-memory
+   plumbing — no upstream tests exist; fixtures required.
+6. Futex provider — fixtures required.
+7. Proc provider (spawn/exec/join simulation) — unskips `popen`,
+   `posix_spawn`, `vfork`.
+8. Signals provider (self-raise at yield points) — fixtures required.
+9. fd-table extraction (fd_renumber/dup2/fdflags, stdio close) —
+   unskips `dup`-class behaviour and `closing-pre-opened-dirs`.
+10. TTY provider + `WASIXWorkerHost` + async syscall bridge.
+
+Drive features (mmap, symlinks, mount) slot in independently of the
+provider slices; sequence by demand.
 
 ## Error model
 
@@ -626,7 +817,17 @@ substrate backward into WASI in its own PR.
 
 ## Open questions
 
-- Exact ABI values and struct layouts for each WASIX syscall — pinned during
-  implementation against the WASIX C headers into `lib/wasix/wasix-32v1.ts`.
-- Exact skip list from `wasix-integration-tests`. Enumerate once the runtime
-  boots the suite end-to-end and apply the "requires Asyncify" rule per test.
+- Exact ABI values and struct layouts for the not-yet-wired WASIX
+  syscalls (sockets, threads, futex, proc, signals, TTY) — pinned per
+  slice against the WASIX C headers into `lib/wasix/wasix-32v1.ts`.
+  (FS/clock/random/cwd are pinned and validated.)
+- ~~Exact skip list.~~ Enumerated: see `tests/wasix-suite.skip.ts`
+  (runtime skips) and `WASIX_BUILD_EXCLUDES` in
+  `tests/wasix-suite.constants.ts` (build excludes); both are enforced
+  by the consistency spec.
+- Fixture format for the thread/socket/TTY slices — WAT vs C-on-wasixcc
+  per capability; decide in each slice PR (see
+  [Coverage gaps](#coverage-gaps-in-the-upstream-suite)).
+- Whether the `wasix_32v1` v2 fd-flags surface (`path_open2` fdflags2
+  bits, `fd_fdflags_*`) gets semantics in Slice 9 or stays stubbed until
+  a binary demands it.

--- a/packages/wasi/lib/wasix/module-imports.ts
+++ b/packages/wasi/lib/wasix/module-imports.ts
@@ -1,0 +1,235 @@
+// Module-instantiation helpers for WASIX: parsing `env.*` import
+// descriptors out of the raw wasm binary, and validating host-supplied
+// memory/table overrides against those descriptors.
+//
+// Kept in a dedicated module (not re-exported from lib/main.ts) so the
+// logic is directly unit-testable without widening the public API.
+
+/**
+ * Descriptor info for the two `env.*` imports that drive WASIX module
+ * instantiation. Either field is absent when the binary doesn't import
+ * the corresponding entity.
+ */
+export type ParsedEnvImports = {
+  memory?: { initial: number; maximum?: number; shared: boolean };
+  table?: {
+    element: "funcref" | "externref";
+    initial: number;
+    maximum?: number;
+  };
+};
+
+/**
+ * Walk the wasm import section just far enough to extract the descriptor
+ * for `env.memory` and `env.__indirect_function_table`. The standard
+ * `WebAssembly.Module.imports()` API only returns `{ module, name, kind }`
+ * — limits and the shared flag are not exposed — so we read them out of
+ * the binary directly. Returns descriptors for whichever of the two are
+ * present; missing entries map to undefined fields.
+ *
+ * The parser only descends into section id 2 (Imports) and stops as soon
+ * as the imports run out. It tolerates unknown leading custom sections.
+ *
+ * Wasm binary layout (relevant subset):
+ *   magic+version (8 bytes), then a sequence of sections:
+ *     section: id:byte, size:varuint32, content:bytes[size]
+ *   Imports section content:
+ *     count:varuint32, entries:Import[count]
+ *   Import:
+ *     module:vec<u8>, name:vec<u8>, kind:byte, descriptor
+ *   Memory descriptor (kind=2):
+ *     limits-flag:byte (bit0=has_max, bit1=shared, bit2=memory64)
+ *     min:varuint32 (or varuint64 if memory64)
+ *     max:varuint32 (or varuint64) if has_max
+ *   Table descriptor (kind=1):
+ *     elem-type:byte (0x70=funcref, 0x6f=externref)
+ *     limits-flag:byte (bit0=has_max), then min, then max if has_max
+ */
+export function parseEnvImportDescriptors(bytes: Uint8Array): ParsedEnvImports {
+  const out: ParsedEnvImports = {};
+
+  // Magic 0x00 0x61 0x73 0x6d ('\0asm') and version 1.
+  if (bytes.length < 8) return out;
+  if (
+    bytes[0] !== 0x00 ||
+    bytes[1] !== 0x61 ||
+    bytes[2] !== 0x73 ||
+    bytes[3] !== 0x6d
+  ) {
+    return out;
+  }
+
+  let offset = 8;
+  const decoder = new TextDecoder();
+
+  while (offset < bytes.length) {
+    const sectionId = bytes[offset++];
+    const [sectionSize, sizeOffset] = readVarUint32(bytes, offset);
+    offset = sizeOffset;
+    const sectionEnd = offset + sectionSize;
+
+    if (sectionId !== 2) {
+      offset = sectionEnd;
+      continue;
+    }
+
+    const [importCount, countOffset] = readVarUint32(bytes, offset);
+    offset = countOffset;
+
+    for (let i = 0; i < importCount; i++) {
+      const [modLen, modLenEnd] = readVarUint32(bytes, offset);
+      offset = modLenEnd;
+      const modName = decoder.decode(bytes.subarray(offset, offset + modLen));
+      offset += modLen;
+
+      const [nmLen, nmLenEnd] = readVarUint32(bytes, offset);
+      offset = nmLenEnd;
+      const importName = decoder.decode(bytes.subarray(offset, offset + nmLen));
+      offset += nmLen;
+
+      const kind = bytes[offset++];
+
+      // 0=function, 1=table, 2=memory, 3=global. We only care about
+      // env.memory and env.__indirect_function_table; everything else
+      // gets skipped past by reading just enough of its descriptor to
+      // advance the cursor.
+      if (kind === 0) {
+        // function: typeidx
+        const [, end] = readVarUint32(bytes, offset);
+        offset = end;
+      } else if (kind === 1) {
+        // table: reftype + limits
+        const elemTypeByte = bytes[offset++];
+        const flags = bytes[offset++];
+        const [initial, afterInitial] = readVarUint32(bytes, offset);
+        offset = afterInitial;
+        let maximum: number | undefined;
+        if (flags & 0x01) {
+          const [max, afterMax] = readVarUint32(bytes, offset);
+          maximum = max;
+          offset = afterMax;
+        }
+        if (modName === "env" && importName === "__indirect_function_table") {
+          const element = elemTypeByte === 0x6f ? "externref" : "funcref";
+          out.table = { element, initial, maximum };
+        }
+      } else if (kind === 2) {
+        // memory: limits with shared bit
+        const flags = bytes[offset++];
+        const isMemory64 = (flags & 0x04) !== 0;
+        const [initial, afterInitial] = isMemory64
+          ? readVarUint64AsNumber(bytes, offset)
+          : readVarUint32(bytes, offset);
+        offset = afterInitial;
+        let maximum: number | undefined;
+        if (flags & 0x01) {
+          const [max, afterMax] = isMemory64
+            ? readVarUint64AsNumber(bytes, offset)
+            : readVarUint32(bytes, offset);
+          maximum = max;
+          offset = afterMax;
+        }
+        if (modName === "env" && importName === "memory") {
+          out.memory = {
+            initial,
+            maximum,
+            shared: (flags & 0x02) !== 0,
+          };
+        }
+      } else if (kind === 3) {
+        // global: valtype + mutability
+        offset += 2;
+      } else {
+        // Unknown kind — bail to be safe rather than misalign the parse.
+        return out;
+      }
+    }
+
+    return out;
+  }
+
+  return out;
+}
+
+export function readVarUint32(
+  bytes: Uint8Array,
+  offset: number,
+): [number, number] {
+  let result = 0;
+  let shift = 0;
+  while (true) {
+    const b = bytes[offset++];
+    result |= (b & 0x7f) << shift;
+    if ((b & 0x80) === 0) break;
+    shift += 7;
+    if (shift > 35) {
+      throw new Error("WASIX: malformed varuint32 in module import section");
+    }
+  }
+  return [result >>> 0, offset];
+}
+
+export function readVarUint64AsNumber(
+  bytes: Uint8Array,
+  offset: number,
+): [number, number] {
+  let result = 0n;
+  let shift = 0n;
+  while (true) {
+    const b = bytes[offset++];
+    result |= BigInt(b & 0x7f) << shift;
+    if ((b & 0x80) === 0) break;
+    shift += 7n;
+    if (shift > 70n) {
+      throw new Error("WASIX: malformed varuint64 in module import section");
+    }
+  }
+  if (result > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error("WASIX: memory64 limit exceeds Number.MAX_SAFE_INTEGER");
+  }
+  return [Number(result), offset];
+}
+
+export function validateMemoryOverride(
+  memory: WebAssembly.Memory,
+  descriptor: { initial: number; maximum?: number; shared: boolean },
+): void {
+  // Engines expose memory.buffer as a SharedArrayBuffer when the
+  // underlying memory is shared.
+  const overrideShared =
+    typeof SharedArrayBuffer !== "undefined" &&
+    memory.buffer instanceof SharedArrayBuffer;
+  if (overrideShared !== descriptor.shared) {
+    throw new Error(
+      `WASIX: provided memory.shared=${overrideShared} does not match ` +
+        `module's env.memory.shared=${descriptor.shared}`,
+    );
+  }
+  const overrideInitial = memory.buffer.byteLength / 65536;
+  if (overrideInitial < descriptor.initial) {
+    throw new Error(
+      `WASIX: provided memory has ${overrideInitial} pages but ` +
+        `module's env.memory requires initial=${descriptor.initial}`,
+    );
+  }
+  // Maximum is not directly observable on the JS side without a private
+  // grow attempt, so we rely on the engine to reject at instantiation
+  // time if the override's max is below the descriptor's max.
+}
+
+export function validateTableOverride(
+  table: WebAssembly.Table,
+  descriptor: { element: string; initial: number; maximum?: number },
+): void {
+  if (table.length < descriptor.initial) {
+    throw new Error(
+      `WASIX: provided indirect function table has length ${table.length} ` +
+        `but module's env.__indirect_function_table requires ` +
+        `initial=${descriptor.initial}`,
+    );
+  }
+  // Element type is not introspectable from JS; the engine rejects on
+  // mismatch at instantiation time. Maximum likewise.
+  void descriptor.element;
+  void descriptor.maximum;
+}

--- a/packages/wasi/lib/wasix/path-utils.ts
+++ b/packages/wasi/lib/wasix/path-utils.ts
@@ -1,0 +1,33 @@
+// Path helpers for the WASIX cwd surface. Dependency-free so they are
+// directly unit-testable; not re-exported from lib/main.ts.
+
+/**
+ * Resolve a guest-supplied path against the current working directory.
+ * Absolute paths (leading `/`) bypass the cwd join. The result is
+ * normalised so `..` segments fold correctly and trailing slashes are
+ * dropped (except for the root).
+ *
+ * Used by `chdir` to compute the absolute target of a relative cwd
+ * change. Other syscalls do not call this — wasix-libc resolves
+ * relative paths against `getcwd()` itself before calling `path_*`,
+ * so by the time a path reaches the runtime it is already preopen-
+ * relative.
+ */
+export function resolveAbsolute(cwd: string, path: string): string {
+  const joined = path.startsWith("/") ? path : `${cwd}/${path}`;
+  const segments = joined.split("/");
+  const out: string[] = [];
+  for (const segment of segments) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") {
+      if (out.length > 0) out.pop();
+      continue;
+    }
+    out.push(segment);
+  }
+  return "/" + out.join("/");
+}
+
+export function stripLeadingSlash(path: string): string {
+  return path.startsWith("/") ? path.slice(1) : path;
+}

--- a/packages/wasi/lib/wasix/wasix.ts
+++ b/packages/wasi/lib/wasix/wasix.ts
@@ -25,6 +25,13 @@ import type {
   FileSystemProvider,
   RandomProvider,
 } from "./providers.js";
+import {
+  ParsedEnvImports,
+  parseEnvImportDescriptors,
+  validateMemoryOverride,
+  validateTableOverride,
+} from "./module-imports.js";
+import { resolveAbsolute, stripLeadingSlash } from "./path-utils.js";
 
 class WASIXExit extends Error {
   code: number;
@@ -882,6 +889,8 @@ export class WASIX {
       proc_raise: enosys,
       proc_spawn: enosys,
       proc_spawn2: enosys, // TODO(slice-7): proc/spawn provider
+      proc_spawn3: enosys, // TODO(slice-7): proc/spawn provider
+      proc_exec4: enosys, // TODO(slice-7): proc/exec provider
       proc_id: enosys,
       proc_parent: enosys,
 
@@ -926,7 +935,15 @@ export class WASIX {
       // Futex
       futex_wait: enosys,
       futex_wake: enosys,
+      futex_wake_all: enosys,
       futex_wake_bitset: enosys,
+
+      // Userspace context switching (wasix-libc green threads /
+      // context-switching test). Needs stack reification — same class
+      // of blocker as Asyncify; stubbed ENOSYS.
+      context_create: enosys,
+      context_destroy: enosys,
+      context_switch: enosys,
 
       // Signals
       signal_register: enosys,
@@ -984,263 +1001,6 @@ export class WASIX {
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
-
-/**
- * Descriptor info for the two `env.*` imports that drive WASIX module
- * instantiation. Either field is absent when the binary doesn't import
- * the corresponding entity.
- */
-type ParsedEnvImports = {
-  memory?: { initial: number; maximum?: number; shared: boolean };
-  table?: {
-    element: "funcref" | "externref";
-    initial: number;
-    maximum?: number;
-  };
-};
-
-/**
- * Walk the wasm import section just far enough to extract the descriptor
- * for `env.memory` and `env.__indirect_function_table`. The standard
- * `WebAssembly.Module.imports()` API only returns `{ module, name, kind }`
- * — limits and the shared flag are not exposed — so we read them out of
- * the binary directly. Returns descriptors for whichever of the two are
- * present; missing entries map to undefined fields.
- *
- * The parser only descends into section id 2 (Imports) and stops as soon
- * as the imports run out. It tolerates unknown leading custom sections.
- *
- * Wasm binary layout (relevant subset):
- *   magic+version (8 bytes), then a sequence of sections:
- *     section: id:byte, size:varuint32, content:bytes[size]
- *   Imports section content:
- *     count:varuint32, entries:Import[count]
- *   Import:
- *     module:vec<u8>, name:vec<u8>, kind:byte, descriptor
- *   Memory descriptor (kind=2):
- *     limits-flag:byte (bit0=has_max, bit1=shared, bit2=memory64)
- *     min:varuint32 (or varuint64 if memory64)
- *     max:varuint32 (or varuint64) if has_max
- *   Table descriptor (kind=1):
- *     elem-type:byte (0x70=funcref, 0x6f=externref)
- *     limits-flag:byte (bit0=has_max), then min, then max if has_max
- */
-function parseEnvImportDescriptors(bytes: Uint8Array): ParsedEnvImports {
-  const out: ParsedEnvImports = {};
-
-  // Magic 0x00 0x61 0x73 0x6d ('\0asm') and version 1.
-  if (bytes.length < 8) return out;
-  if (
-    bytes[0] !== 0x00 ||
-    bytes[1] !== 0x61 ||
-    bytes[2] !== 0x73 ||
-    bytes[3] !== 0x6d
-  ) {
-    return out;
-  }
-
-  let offset = 8;
-  const decoder = new TextDecoder();
-
-  while (offset < bytes.length) {
-    const sectionId = bytes[offset++];
-    const [sectionSize, sizeOffset] = readVarUint32(bytes, offset);
-    offset = sizeOffset;
-    const sectionEnd = offset + sectionSize;
-
-    if (sectionId !== 2) {
-      offset = sectionEnd;
-      continue;
-    }
-
-    const [importCount, countOffset] = readVarUint32(bytes, offset);
-    offset = countOffset;
-
-    for (let i = 0; i < importCount; i++) {
-      const [modLen, modLenEnd] = readVarUint32(bytes, offset);
-      offset = modLenEnd;
-      const modName = decoder.decode(bytes.subarray(offset, offset + modLen));
-      offset += modLen;
-
-      const [nmLen, nmLenEnd] = readVarUint32(bytes, offset);
-      offset = nmLenEnd;
-      const importName = decoder.decode(bytes.subarray(offset, offset + nmLen));
-      offset += nmLen;
-
-      const kind = bytes[offset++];
-
-      // 0=function, 1=table, 2=memory, 3=global. We only care about
-      // env.memory and env.__indirect_function_table; everything else
-      // gets skipped past by reading just enough of its descriptor to
-      // advance the cursor.
-      if (kind === 0) {
-        // function: typeidx
-        const [, end] = readVarUint32(bytes, offset);
-        offset = end;
-      } else if (kind === 1) {
-        // table: reftype + limits
-        const elemTypeByte = bytes[offset++];
-        const flags = bytes[offset++];
-        const [initial, afterInitial] = readVarUint32(bytes, offset);
-        offset = afterInitial;
-        let maximum: number | undefined;
-        if (flags & 0x01) {
-          const [max, afterMax] = readVarUint32(bytes, offset);
-          maximum = max;
-          offset = afterMax;
-        }
-        if (modName === "env" && importName === "__indirect_function_table") {
-          const element = elemTypeByte === 0x6f ? "externref" : "funcref";
-          out.table = { element, initial, maximum };
-        }
-      } else if (kind === 2) {
-        // memory: limits with shared bit
-        const flags = bytes[offset++];
-        const isMemory64 = (flags & 0x04) !== 0;
-        const [initial, afterInitial] = isMemory64
-          ? readVarUint64AsNumber(bytes, offset)
-          : readVarUint32(bytes, offset);
-        offset = afterInitial;
-        let maximum: number | undefined;
-        if (flags & 0x01) {
-          const [max, afterMax] = isMemory64
-            ? readVarUint64AsNumber(bytes, offset)
-            : readVarUint32(bytes, offset);
-          maximum = max;
-          offset = afterMax;
-        }
-        if (modName === "env" && importName === "memory") {
-          out.memory = {
-            initial,
-            maximum,
-            shared: (flags & 0x02) !== 0,
-          };
-        }
-      } else if (kind === 3) {
-        // global: valtype + mutability
-        offset += 2;
-      } else {
-        // Unknown kind — bail to be safe rather than misalign the parse.
-        return out;
-      }
-    }
-
-    return out;
-  }
-
-  return out;
-}
-
-function readVarUint32(bytes: Uint8Array, offset: number): [number, number] {
-  let result = 0;
-  let shift = 0;
-  while (true) {
-    const b = bytes[offset++];
-    result |= (b & 0x7f) << shift;
-    if ((b & 0x80) === 0) break;
-    shift += 7;
-    if (shift > 35) {
-      throw new Error("WASIX: malformed varuint32 in module import section");
-    }
-  }
-  return [result >>> 0, offset];
-}
-
-function readVarUint64AsNumber(
-  bytes: Uint8Array,
-  offset: number,
-): [number, number] {
-  let result = 0n;
-  let shift = 0n;
-  while (true) {
-    const b = bytes[offset++];
-    result |= BigInt(b & 0x7f) << shift;
-    if ((b & 0x80) === 0) break;
-    shift += 7n;
-    if (shift > 70n) {
-      throw new Error("WASIX: malformed varuint64 in module import section");
-    }
-  }
-  if (result > BigInt(Number.MAX_SAFE_INTEGER)) {
-    throw new Error("WASIX: memory64 limit exceeds Number.MAX_SAFE_INTEGER");
-  }
-  return [Number(result), offset];
-}
-
-function validateMemoryOverride(
-  memory: WebAssembly.Memory,
-  descriptor: { initial: number; maximum?: number; shared: boolean },
-): void {
-  // Engines expose memory.buffer as a SharedArrayBuffer when the
-  // underlying memory is shared.
-  const overrideShared =
-    typeof SharedArrayBuffer !== "undefined" &&
-    memory.buffer instanceof SharedArrayBuffer;
-  if (overrideShared !== descriptor.shared) {
-    throw new Error(
-      `WASIX: provided memory.shared=${overrideShared} does not match ` +
-        `module's env.memory.shared=${descriptor.shared}`,
-    );
-  }
-  const overrideInitial = memory.buffer.byteLength / 65536;
-  if (overrideInitial < descriptor.initial) {
-    throw new Error(
-      `WASIX: provided memory has ${overrideInitial} pages but ` +
-        `module's env.memory requires initial=${descriptor.initial}`,
-    );
-  }
-  // Maximum is not directly observable on the JS side without a private
-  // grow attempt, so we rely on the engine to reject at instantiation
-  // time if the override's max is below the descriptor's max.
-}
-
-function validateTableOverride(
-  table: WebAssembly.Table,
-  descriptor: { element: string; initial: number; maximum?: number },
-): void {
-  if (table.length < descriptor.initial) {
-    throw new Error(
-      `WASIX: provided indirect function table has length ${table.length} ` +
-        `but module's env.__indirect_function_table requires ` +
-        `initial=${descriptor.initial}`,
-    );
-  }
-  // Element type is not introspectable from JS; the engine rejects on
-  // mismatch at instantiation time. Maximum likewise.
-  void descriptor.element;
-  void descriptor.maximum;
-}
-
-/**
- * Resolve a guest-supplied path against the current working directory.
- * Absolute paths (leading `/`) bypass the cwd join. The result is
- * normalised so `..` segments fold correctly and trailing slashes are
- * dropped (except for the root).
- *
- * Used by `chdir` to compute the absolute target of a relative cwd
- * change. Other syscalls do not call this — wasix-libc resolves
- * relative paths against `getcwd()` itself before calling `path_*`,
- * so by the time a path reaches the runtime it is already preopen-
- * relative.
- */
-function resolveAbsolute(cwd: string, path: string): string {
-  const joined = path.startsWith("/") ? path : `${cwd}/${path}`;
-  const segments = joined.split("/");
-  const out: string[] = [];
-  for (const segment of segments) {
-    if (segment === "" || segment === ".") continue;
-    if (segment === "..") {
-      if (out.length > 0) out.pop();
-      continue;
-    }
-    out.push(segment);
-  }
-  return "/" + out.join("/");
-}
-
-function stripLeadingSlash(path: string): string {
-  return path.startsWith("/") ? path.slice(1) : path;
-}
 
 function readString(
   memory: WebAssembly.Memory,

--- a/packages/wasi/package.json
+++ b/packages/wasi/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "dev": "vite --port 5173",
     "build:docs": "typedoc --options typedoc.config.cjs",
-    "build:tests": "cd programs && cargo wasi build -r && cd .. && cp programs/target/wasm32-wasi/release/*.wasi.wasm public/bin/tests/ && wat2wasm programs/wasix-clock-random/wasix-clock-random.wat -o public/bin/tests/wasix-clock-random.wasm && wat2wasm programs/wasix-deterministic/wasix-deterministic.wat -o public/bin/tests/wasix-deterministic.wasm",
+    "build:tests": "cd programs && cargo wasi build -r && cd .. && cp programs/target/wasm32-wasi/release/*.wasi.wasm public/bin/tests/ && wat2wasm programs/wasix-clock-random/wasix-clock-random.wat -o public/bin/tests/wasix-clock-random.wasm && wat2wasm programs/wasix-deterministic/wasix-deterministic.wat -o public/bin/tests/wasix-deterministic.wasm && wat2wasm programs/wasix-errno/wasix-errno.wat -o public/bin/tests/wasix-errno.wasm",
     "build:vite": "tsc --noEmit && vite build",
     "build": "npm run build:docs && npm run build:vite && rimraf dist/src && mv dist/lib/* dist/ && rmdir dist/lib",
     "test:server": "vite --port 5173",

--- a/packages/wasi/programs/wasix-errno/wasix-errno.wat
+++ b/packages/wasi/programs/wasix-errno/wasix-errno.wat
@@ -1,0 +1,26 @@
+;; Error-model probe: calls wasix_32v1 random_get and exits with the
+;; returned errno as the process exit code. Lets the Playwright error-model
+;; spec observe exactly which errno a throwing provider produced:
+;;
+;;   provider ok                          → exit 0
+;;   provider throws WASIXError(result)   → exit <result>
+;;   provider throws anything else        → exit EIO (29)
+;;
+;; Build: wat2wasm wasix-errno.wat -o wasix-errno.wasm
+
+(module
+  ;; random_get(buf: i32, buf_len: i32) -> i32 (errno)
+  (import "wasix_32v1" "random_get"
+    (func $random_get (param i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "proc_exit"
+    (func $proc_exit (param i32)))
+
+  (memory (;0;) 1)
+  (export "memory" (memory 0))
+  (export "_start" (func $start))
+
+  (func $start
+    i32.const 16  ;; buf
+    i32.const 8   ;; buf_len
+    call $random_get
+    call $proc_exit))

--- a/packages/wasi/src/main.ts
+++ b/packages/wasi/src/main.ts
@@ -9,6 +9,7 @@ import {
   FixedClockProvider,
   SeededRandomProvider,
   WASIDriveFileSystemProvider,
+  WASIX32v1,
 } from "../lib/main.js";
 
 (window as any)["WASI"] = WASI;
@@ -20,6 +21,7 @@ import {
 (window as any)["FixedClockProvider"] = FixedClockProvider;
 (window as any)["SeededRandomProvider"] = SeededRandomProvider;
 (window as any)["WASIDriveFileSystemProvider"] = WASIDriveFileSystemProvider;
+(window as any)["WASIX32v1"] = WASIX32v1;
 
 const programSelect = document.getElementById("program")! as HTMLSelectElement;
 const argsInput = document.getElementById("args")! as HTMLInputElement;

--- a/packages/wasi/tests/build-wasix-suite.ts
+++ b/packages/wasi/tests/build-wasix-suite.ts
@@ -7,17 +7,25 @@
 //     at the SHA pinned in `wasix-suite.constants.ts`.
 //   - `wasixcc` is on PATH. Locally: `npm run wasix:install-tools`.
 //
-// Behaviour:
-//   - For each directory in `resolveWasixIncludeDirs()`, build
-//     `tests/wasix-vendor/wasmer/tests/wasix/<dir>/main.c` into
-//     `public/bin/wasix-tests/<dir>.wasm`.
-//   - If the source directory has no C sources, log and continue (the
-//     vendored upstream may have non-C subdirs we don't compile).
+// Behaviour mirrors upstream `wasmer/tests/wasix/test.sh`:
+//   - C tests build with `wasixcc -sWASM_EXCEPTIONS=false <sources>`,
+//     C++ tests (main.cc) with `wasix++ <sources>`. Per-test extra
+//     flags come from an optional `.flags` file, exactly like upstream.
+//   - Upstream `.no-build` tests compile inside their own run.sh with
+//     equivalent flags (WASIXCC_WASM_EXCEPTIONS=no ≈
+//     -sWASM_EXCEPTIONS=false); we build them with the plain invocation,
+//     which matches the non-exceptions variant that our spec replicates.
 //   - If `wasixcc` is missing, the vendor dir is missing, or any
 //     individual build fails, exit non-zero. Build failures are not
 //     silently absorbed: the fix is to repair the build, not to skip.
 
-import { existsSync, mkdirSync, readdirSync, statSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+} from "node:fs";
 import { spawnSync } from "node:child_process";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -69,29 +77,37 @@ for (const name of WASIX_INCLUDE_DIRS) {
     process.exit(1);
   }
 
-  const sources = collectSources(srcDir);
-  if (sources.length === 0) {
+  const cSources = collectSources(srcDir, ".c");
+  const cppSources = collectSources(srcDir, ".cc");
+  if (cSources.length === 0 && cppSources.length === 0) {
     console.error(
-      `[build-wasix-suite] include-list entry has no C sources: ${name}\n` +
+      `[build-wasix-suite] include-list entry has no C/C++ sources: ${name}\n` +
         "  Drop it from WASIX_INCLUDE_DIRS or fix the vendored checkout.",
     );
     process.exit(1);
   }
 
   const outPath = join(outDir, `${name}.wasm`);
-  // Several upstream wasmer tests call fork() / etc. without including
-  // the right wasix-libc headers. wasixcc's clang (C99+) rejects the
-  // implicit declarations as errors; demote to warnings so the
-  // resulting binaries still link against the wasix-libc symbols.
+  const extraFlags = readFlags(srcDir);
+
+  // Mirror upstream test.sh:
+  //   wasix++ main.cc -o main.wasm ${extra_flags}          (C++ tests)
+  //   wasixcc -sWASM_EXCEPTIONS=false main.c ... ${flags}  (C tests)
+  // Plus -Wno-error=implicit-function-declaration: several upstream
+  // tests call fork() etc. without the right headers and wasixcc's
+  // clang rejects the implicit declarations as errors by default.
+  const isCpp = cppSources.length > 0;
+  const compiler = isCpp ? "wasix++" : wasixcc;
   const args = [
-    "-O2",
+    ...(isCpp ? [] : ["-sWASM_EXCEPTIONS=false"]),
     "-Wno-error=implicit-function-declaration",
     "-o",
     outPath,
-    ...sources,
+    ...(isCpp ? cppSources : cSources),
+    ...extraFlags,
   ];
 
-  const result = spawnSync(wasixcc, args, {
+  const result = spawnSync(compiler, args, {
     stdio: ["ignore", "inherit", "inherit"],
   });
 
@@ -133,13 +149,22 @@ function resolveWasixcc(): string | null {
   return probe.status === 0 ? "wasixcc" : null;
 }
 
-/** Collect `.c` files directly under `dir` (non-recursive). */
-function collectSources(dir: string): string[] {
+/** Collect source files with the given extension directly under `dir`. */
+function collectSources(dir: string, ext: ".c" | ".cc"): string[] {
   const out: string[] = [];
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry);
     if (!statSync(full).isFile()) continue;
-    if (entry.endsWith(".c")) out.push(full);
+    if (entry.endsWith(ext)) out.push(full);
   }
   return out;
+}
+
+/** Read the upstream per-test `.flags` file (whitespace-separated). */
+function readFlags(dir: string): string[] {
+  const flagsPath = join(dir, ".flags");
+  if (!existsSync(flagsPath)) return [];
+  return readFileSync(flagsPath, "utf8")
+    .split(/\s+/)
+    .filter((f) => f.length > 0);
 }

--- a/packages/wasi/tests/install-wasix-tools.sh
+++ b/packages/wasi/tests/install-wasix-tools.sh
@@ -47,11 +47,39 @@ install_wasixcc() {
     note "wasixcc: already installed ($(wasixcc --version 2>/dev/null | head -n1 || echo unknown))"
     return 0
   fi
-  # No automated installer for wasixcc outside CI yet — the upstream
-  # composite action (wasix-org/wasixcc) is GitHub-Actions-only. Print
-  # the installation pointer and exit non-zero so callers know the
-  # toolchain is incomplete.
-  fail "wasixcc not on PATH — install via https://github.com/wasix-org/wasix-libc and the matching wasix-toolchain LLVM build"
+
+  # Install the pinned wasixcc release binary (wasixccenv), which
+  # downloads the sysroot / LLVM / binaryen into ~/.wasixcc and symlinks
+  # the wasixcc / wasix++ / wasixld executables into ~/.local/bin.
+  local version="v0.4.3"
+  local arch os target
+  arch="$(uname -m)"
+  os="$(uname -s)"
+  case "$os-$arch" in
+    Darwin-arm64) target="aarch64-apple-darwin" ;;
+    Darwin-x86_64) target="x86_64-apple-darwin" ;;
+    Linux-aarch64) target="aarch64-unknown-linux-gnu" ;;
+    Linux-x86_64) target="x86_64-unknown-linux-gnu" ;;
+    *) fail "unsupported platform $os/$arch — install wasixcc manually from https://github.com/wasix-org/wasixcc" ;;
+  esac
+
+  note "wasixcc: installing $version for $target"
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  curl -fsSL -o "$tmpdir/wasixcc.tar.gz" \
+    "https://github.com/wasix-org/wasixcc/releases/download/$version/wasixcc-$target.tar.gz" \
+    || fail "download of wasixcc $version failed"
+  tar -xzf "$tmpdir/wasixcc.tar.gz" -C "$tmpdir" || fail "extract failed"
+  mkdir -p "$HOME/.local/bin"
+  "$tmpdir/wasixccenv" download-all || fail "wasixccenv download-all failed"
+  "$tmpdir/wasixccenv" install-executables "$HOME/.local/bin" \
+    || fail "wasixccenv install-executables failed"
+  rm -rf "$tmpdir"
+
+  if ! have wasixcc; then
+    note "wasixcc installed to ~/.local/bin — add it to your PATH:"
+    note '  export PATH="$HOME/.local/bin:$PATH"'
+  fi
 }
 
 install_wabt

--- a/packages/wasi/tests/wasix-error-model.spec.ts
+++ b/packages/wasi/tests/wasix-error-model.spec.ts
@@ -1,0 +1,101 @@
+// Error-model boundary tests (WASIX-PLAN.md "Error model"):
+//
+//   - Provider throws a `WASIXError` subclass → its `.result` is returned
+//     as the syscall's errno.
+//   - Provider throws anything else → syscall returns EIO; the thrown
+//     value is NOT propagated across the WASM boundary (the guest sees a
+//     normal errno, `WASIX.start` resolves normally).
+//
+// Uses the `wasix-errno.wasm` probe, which calls `random_get` and exits
+// with the returned errno as the process exit code — so the exact errno
+// the guest observed is visible from outside.
+
+import { test, expect } from "@playwright/test";
+
+import type {
+  WASIX,
+  WASIXContext,
+  WASIDriveFileSystemProvider,
+  WASIX32v1,
+} from "../lib/main";
+
+const EACCES = 2;
+const EIO = 29;
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("http://localhost:5173");
+  await page.waitForLoadState("domcontentloaded");
+});
+
+async function runErrnoProbe(
+  page: import("@playwright/test").Page,
+  providerKind: "ok" | "throws-wasix-error" | "throws-plain-error",
+): Promise<{ exitCode: number; threw: string | null }> {
+  return page.evaluate(async function (kind) {
+    while ((window as any)["WASIX"] === undefined) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+
+    const W: typeof WASIX = (window as any)["WASIX"];
+    const WC: typeof WASIXContext = (window as any)["WASIXContext"];
+    const WD: typeof WASIDriveFileSystemProvider = (window as any)[
+      "WASIDriveFileSystemProvider"
+    ];
+    const ABI: typeof WASIX32v1 = (window as any)["WASIX32v1"];
+
+    const random =
+      kind === "ok"
+        ? undefined
+        : {
+            fill: () => {
+              if (kind === "throws-wasix-error") {
+                // Result.EACCES === 2
+                throw new ABI.WASIXError(2);
+              }
+              throw new Error("provider exploded");
+            },
+          };
+
+    let threw: string | null = null;
+    let exitCode = -1;
+    try {
+      const result = await W.start(
+        fetch("/bin/tests/wasix-errno.wasm"),
+        new WC({
+          args: [],
+          random,
+          stdout: () => {},
+          stderr: () => {},
+          stdin: () => null,
+          fs: new WD({}),
+        }),
+      );
+      exitCode = result.exitCode;
+    } catch (e: any) {
+      threw = `${e?.message ?? e}`;
+    }
+    return { exitCode, threw };
+  }, providerKind);
+}
+
+test("healthy provider: guest sees errno 0", async ({ page }) => {
+  const result = await runErrnoProbe(page, "ok");
+  expect(result.threw).toBe(null);
+  expect(result.exitCode).toBe(0);
+});
+
+test("provider throws WASIXError: guest sees that errno, no JS propagation", async ({
+  page,
+}) => {
+  const result = await runErrnoProbe(page, "throws-wasix-error");
+  expect(result.threw).toBe(null);
+  expect(result.exitCode).toBe(EACCES);
+});
+
+test("provider throws a plain Error: guest sees EIO, no JS propagation", async ({
+  page,
+}) => {
+  const result = await runErrnoProbe(page, "throws-plain-error");
+  expect(result.threw).toBe(null);
+  expect(result.exitCode).toBe(EIO);
+});

--- a/packages/wasi/tests/wasix-preview1-corpus.spec.ts
+++ b/packages/wasi/tests/wasix-preview1-corpus.spec.ts
@@ -1,0 +1,162 @@
+// Runs the existing preview1 test corpus (caspervonb/wasi-test-suite)
+// through WASIX instead of WASI.
+//
+// Why this exists: WASIX composes a WASI instance internally but
+// OVERRIDES nine preview1 imports (fd_prestat_get/dir_name, fd_readdir,
+// path_open, path_filestat_get, path_create_directory,
+// path_remove_directory, path_unlink_file, path_rename) so they route
+// through the FileSystemProvider. preview1 behaviour under WASIX is
+// therefore a distinct code path from preview1 under WASI, and the
+// corpus that validates WASI never touched it. This spec closes that
+// hole — it also exercises the export-memory auto-detect path (corpus
+// binaries export their memory rather than importing env.memory).
+//
+// Expectations are identical to core.spec.ts / libc.spec.ts /
+// libstd.spec.ts: exit status from the .status file (default 0), plus
+// stdout/stderr golden files when present.
+
+import * as fs from "fs";
+
+import { test, expect } from "@playwright/test";
+
+import type {
+  WASIX,
+  WASIXContext,
+  WASIDriveFileSystemProvider,
+} from "../lib/main";
+import {
+  Suite,
+  getArgs,
+  getEnv,
+  getStatus,
+  getStdin,
+  getStderr,
+  getStdout,
+  getFS,
+} from "./helpers.js";
+
+const SUITES: Suite[] = ["core", "libc", "libstd"];
+
+/**
+ * Corpus tests whose expectations are WASI-shaped in a way WASIX
+ * intentionally diverges from. Add entries ONLY for documented semantic
+ * differences (with the reason inline), never for convenience.
+ */
+const WASIX_CORPUS_SKIPS: Record<string, string> = {
+  // WASIX deliberately speaks POSIX errno vocabulary: the provider layer
+  // translates the drive's ENOTCAPABLE ("not present" / "escapes the
+  // preopen") into ENOENT, because wasix-libc consumers and the wasmer
+  // suite expect POSIX shapes (see the Slice 3.5 notes and the
+  // wasix-fs-provider spec). These three corpus tests assert
+  // errno == ENOTCAPABLE specifically, which is preview1-under-WASI
+  // behaviour — under WASIX the same operations fail with ENOENT and
+  // the guest's assert exits 134. Expected divergence, marked
+  // test.fail so any behaviour change is flagged.
+  "libc/fopen-directory-parent-directory.wasm":
+    "asserts ENOTCAPABLE; WASIX provider layer maps to POSIX ENOENT",
+  "libc/fopen-parent-directory.wasm":
+    "asserts ENOTCAPABLE; WASIX provider layer maps to POSIX ENOENT",
+  "libc/fopen-working-directory.wasm":
+    "asserts ENOTCAPABLE; WASIX provider layer maps to POSIX ENOENT",
+};
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("http://localhost:5173");
+  await page.waitForLoadState("domcontentloaded");
+});
+
+for (const suite of SUITES) {
+  let wasmFiles: string[] = [];
+  try {
+    wasmFiles = fs
+      .readdirSync(`public/bin/wasi-test-suite-main/${suite}`)
+      .filter((f) => f.endsWith(".wasm"));
+  } catch {
+    // Missing corpus is surfaced by the guard test below.
+  }
+
+  test.describe(`wasix-preview1-corpus/${suite}`, () => {
+    test(`corpus is present`, () => {
+      expect(
+        wasmFiles.length,
+        `public/bin/wasi-test-suite-main/${suite} is empty — run ` +
+          "`npm run test:download`.",
+      ).toBeGreaterThan(0);
+    });
+
+    for (const name of wasmFiles) {
+      const expectedStatus = getStatus(suite, name);
+      const env = getEnv(suite, name);
+      // libstd binaries read their own name as argv[0] plus .arg files;
+      // mirrors libstd.spec.ts. Harmless for core/libc.
+      const args = [name, ...getArgs(suite, name)];
+      const stdin = getStdin(suite, name);
+      const stdout = getStdout(suite, name);
+      const stderr = getStderr(suite, name);
+      const testFS = getFS(suite, name);
+      const skipReason = WASIX_CORPUS_SKIPS[`${suite}/${name}`];
+
+      test(`${name} exits ${expectedStatus} under WASIX`, async ({ page }) => {
+        if (skipReason) {
+          test.fail(true, skipReason);
+        }
+
+        const result = await page.evaluate(
+          async function ({ url, env, args, stdin, testFS }) {
+            while ((window as any)["WASIX"] === undefined) {
+              await new Promise((resolve) => setTimeout(resolve, 10));
+            }
+
+            const W: typeof WASIX = (window as any)["WASIX"];
+            const WC: typeof WASIXContext = (window as any)["WASIXContext"];
+            const WD: typeof WASIDriveFileSystemProvider = (window as any)[
+              "WASIDriveFileSystemProvider"
+            ];
+
+            let stderr = "";
+            let stdout = "";
+            // Chunk stdin by maxByteLength, mirroring libstd.spec.ts —
+            // large inputs (io_stdin-beowulf) overflow the guest buffer
+            // if returned in one piece.
+            let stdinBytes = new TextEncoder().encode(stdin ?? "");
+            const wasiResult = await W.start(
+              fetch(url),
+              new WC({
+                args,
+                env,
+                stdout: (s: string) => {
+                  stdout += s;
+                },
+                stderr: (s: string) => {
+                  stderr += s;
+                },
+                stdin: (maxByteLength: number) => {
+                  const chunk = stdinBytes.slice(0, maxByteLength);
+                  stdinBytes = stdinBytes.slice(maxByteLength);
+                  return new TextDecoder().decode(chunk);
+                },
+                fs: new WD(testFS),
+              }),
+            );
+            return { exitCode: wasiResult.exitCode, stdout, stderr };
+          },
+          {
+            url: `/bin/wasi-test-suite-main/${suite}/${name}`,
+            env,
+            args,
+            stdin,
+            testFS,
+          },
+        );
+
+        expect(result.exitCode).toBe(expectedStatus);
+        if (stdout) {
+          expect(result.stdout).toEqual(stdout);
+        }
+        if (stderr) {
+          expect(result.stderr).toEqual(stderr);
+        }
+      });
+    }
+  });
+}

--- a/packages/wasi/tests/wasix-suite-consistency.spec.ts
+++ b/packages/wasi/tests/wasix-suite-consistency.spec.ts
@@ -1,0 +1,109 @@
+// Consistency checks for the wasix suite metadata. Pure Node-side —
+// no browser page involved. These exist so the suite's coverage
+// denominator stays visible and honest:
+//
+//   1. WASIX_INCLUDE_DIRS ∪ WASIX_BUILD_EXCLUDES exactly partitions the
+//      vendored upstream test directories. A wasmer SHA bump that adds a
+//      new upstream test fails here until the new test is classified.
+//   2. Every WASIX_SUITE_SKIPS key refers to a test that is actually
+//      built and run (i.e. is in WASIX_INCLUDE_DIRS). Skip entries for
+//      unbuilt or non-existent tests are dead metadata — they caused a
+//      long-standing situation where the skip map implied coverage the
+//      harness never had.
+//   3. The lists stay alphabetised (they're hand-maintained grep
+//      targets).
+//
+// When the vendor checkout is missing locally the partition test is
+// skipped (CI always fetches the vendor before running).
+
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { test, expect } from "@playwright/test";
+
+import {
+  WASIX_BUILD_EXCLUDES,
+  WASIX_INCLUDE_DIRS,
+  WASIX_VENDOR_DIR,
+} from "./wasix-suite.constants";
+import { WASIX_SUITE_SKIPS } from "./wasix-suite.skip";
+
+const pkgDir = process.cwd();
+const wasixTestsDir = join(
+  pkgDir,
+  WASIX_VENDOR_DIR,
+  "wasmer",
+  "tests",
+  "wasix",
+);
+
+function listVendorTestDirs(): string[] {
+  return readdirSync(wasixTestsDir)
+    .filter((entry) => statSync(join(wasixTestsDir, entry)).isDirectory())
+    .sort();
+}
+
+test.describe("wasix suite metadata consistency", () => {
+  test("include list and build excludes exactly partition the vendored tests", () => {
+    test.skip(
+      !existsSync(wasixTestsDir),
+      "vendor checkout missing — run `npm run test:prepare:wasmer`",
+    );
+
+    const vendorDirs = listVendorTestDirs();
+    const include = new Set(WASIX_INCLUDE_DIRS);
+    const exclude = new Set(Object.keys(WASIX_BUILD_EXCLUDES));
+
+    const overlap = [...include].filter((name) => exclude.has(name));
+    expect(
+      overlap,
+      "tests listed in BOTH WASIX_INCLUDE_DIRS and WASIX_BUILD_EXCLUDES",
+    ).toEqual([]);
+
+    const unclassified = vendorDirs.filter(
+      (name) => !include.has(name) && !exclude.has(name),
+    );
+    expect(
+      unclassified,
+      "upstream test dirs missing from both WASIX_INCLUDE_DIRS and " +
+        "WASIX_BUILD_EXCLUDES — classify them (usually after a SHA bump)",
+    ).toEqual([]);
+
+    const vendorSet = new Set(vendorDirs);
+    const staleInclude = [...include].filter((name) => !vendorSet.has(name));
+    expect(
+      staleInclude,
+      "WASIX_INCLUDE_DIRS entries that no longer exist upstream",
+    ).toEqual([]);
+
+    const staleExclude = [...exclude].filter((name) => !vendorSet.has(name));
+    expect(
+      staleExclude,
+      "WASIX_BUILD_EXCLUDES entries that no longer exist upstream",
+    ).toEqual([]);
+  });
+
+  test("every skip entry refers to a test that is built and run", () => {
+    const include = new Set(WASIX_INCLUDE_DIRS);
+    const deadSkips = Object.keys(WASIX_SUITE_SKIPS).filter(
+      (name) => !include.has(name),
+    );
+    expect(
+      deadSkips,
+      "WASIX_SUITE_SKIPS keys not present in WASIX_INCLUDE_DIRS — a skip " +
+        "for a test that is never built is dead metadata; move it to " +
+        "WASIX_BUILD_EXCLUDES or delete it",
+    ).toEqual([]);
+  });
+
+  test("hand-maintained lists stay alphabetised", () => {
+    const sortedInclude = [...WASIX_INCLUDE_DIRS].sort();
+    expect(WASIX_INCLUDE_DIRS).toEqual(sortedInclude);
+
+    const excludeKeys = Object.keys(WASIX_BUILD_EXCLUDES);
+    expect(excludeKeys).toEqual([...excludeKeys].sort());
+
+    const skipKeys = Object.keys(WASIX_SUITE_SKIPS);
+    expect(skipKeys).toEqual([...skipKeys].sort());
+  });
+});

--- a/packages/wasi/tests/wasix-suite.constants.ts
+++ b/packages/wasi/tests/wasix-suite.constants.ts
@@ -7,7 +7,10 @@
  *   1. Update the constant here.
  *   2. Re-run `npm run test:prepare:wasmer` to refresh the vendored
  *      `tests/wasix-vendor/wasmer/` checkout.
- *   3. Triage any newly-failing tests into `wasix-suite.skip.ts`.
+ *   3. Run the consistency spec (`wasix-suite-consistency.spec.ts`) — it
+ *      fails if any new upstream test dir is missing from both
+ *      `WASIX_INCLUDE_DIRS` and `WASIX_BUILD_EXCLUDES`.
+ *   4. Triage any newly-failing tests into `wasix-suite.skip.ts`.
  */
 export const WASMER_SHA = "261a337d428148a9f06884c10478dd634a1f1da7";
 
@@ -24,33 +27,65 @@ export const WASIX_VENDOR_DIR = "tests/wasix-vendor";
 export const WASIX_SUITE_BIN_DIR = "public/bin/wasix-tests";
 
 /**
+ * Validation contract (audited 2026-07 against WASMER_SHA):
+ *
+ * Upstream `run.sh` scripts validate in one or both of two ways —
+ *   1. Exit code: `set -e` plus the binary exiting non-zero on failure.
+ *      Every included test's `main.c` self-asserts (assert / exit(1) /
+ *      EXIT_FAILURE paths); none rely solely on host-side checks.
+ *   2. Stdout diff: `$WASMER_RUN main.wasm … > output` followed by
+ *      `printf "<expected>" | diff -u output -`. Most included tests
+ *      use this — the binary usually prints "0" (no newline) on
+ *      success. Exit-code-only checking is NOT sufficient for these
+ *      (`closing-pre-opened-dirs` passed vacuously for months that
+ *      way); the Playwright spec parses the printf/diff pattern out of
+ *      run.sh and asserts stdout equality per run. Scripts WITHOUT
+ *      `set -e` ignore guest exit codes entirely (`exception` exits 42
+ *      by design) — the spec mirrors that rule too.
+ *
+ * Additional harness caveats discovered in the audit:
+ *   - Several run.sh scripts invoke the binary multiple times with
+ *     different subcommands (`udp` ×4, `vfork` ×9, `popen` ×3,
+ *     `posix_spawn` ×3). The spec runs every `$WASMER_RUN main.wasm`
+ *     line, sharing the volume filesystem state across invocations the
+ *     way the wasmer runner's host mount does.
+ *   - `popen` / `posix_spawn` / `vfork` compile inside run.sh with
+ *     special flags (WASIXCC_WASM_EXCEPTIONS / WASIXCC_PIC / wasm-opt
+ *     --asyncify). Our generic `wasixcc -O2` build corresponds to the
+ *     non-asyncified variant, which is the variant upstream runs for the
+ *     invocations we replicate. vfork's `main-eh.wasm` variant is not
+ *     reproduced.
+ *   - `symlink-open-read-write` pre-seeds `target.txt` via run.sh and
+ *     post-asserts its content on the host side; the harness must
+ *     synthesise that input when the test is unskipped.
+ *   - `fs-mount` validates three mount mechanisms (--volume, wasmer.toml,
+ *     webc); only the `--volume` invocation is reproducible here.
+ */
+
+/**
  * Hand-maintained list of `wasmer/tests/wasix/<dir>` test cases the build
  * harness will compile and the Playwright spec will run.
  *
- * The set is the intersection of:
- *   1. Tests in upstream `wasmer/tests/wasix/` at `WASMER_SHA`.
- *   2. Tests that compile and link against the wasix-libc sysroot
- *      shipped by `wasix-org/wasixcc@v0.4.3`. Tests that need
- *      `fork` / `pthread_create` / `dlopen` / `<dlfcn.h>` are excluded
- *      because the linkable symbols aren't present in this toolchain
- *      release. They re-enter the set when the toolchain (or a
- *      provider) makes them buildable.
- *
- * The runtime skip map in `wasix-suite.skip.ts` covers tests that
- * *do* build but exercise capabilities not yet wired into WASIX
- * (sockets, signals, etc.).
+ * Together with `WASIX_BUILD_EXCLUDES` this must exactly cover the test
+ * directories in the vendored checkout — the consistency spec enforces
+ * the partition, so a SHA bump that adds upstream tests fails loudly
+ * instead of silently shrinking coverage.
  *
  * Keep alphabetised.
  */
 export const WASIX_INCLUDE_DIRS: readonly string[] = [
+  "cloexec",
   "closing-pre-opened-dirs",
+  "context-switching",
   "create-and-remove-dirs",
   "create-dir-at-cwd",
   "create-dir-at-cwd-with-chdir",
   "cross-fs-rename",
   "cwd-to-home",
   "distinct-inodes-same-basename",
+  "exception",
   "fd-close",
+  "fork",
   "fs-mount",
   "fstatat-with-chdir",
   "mount-tmp-locally",
@@ -61,11 +96,64 @@ export const WASIX_INCLUDE_DIRS: readonly string[] = [
   "munmap-sync-middle-of-file",
   "munmap-sync-start-of-file",
   "open-under-file",
+  "pipes",
   "popen",
   "posix_spawn",
+  "proc-exec",
+  "proc-exec2",
   "pwrite-and-size",
   "read-after-munmap",
+  "setjmp-longjmp",
+  "share-tmp-after-fork",
+  "share-tmp-after-proc-exec",
+  "share-tmp-after-proc-exec2",
+  "shared-fd",
+  "signal",
   "symlink-open-read-write",
   "udp",
   "vfork",
 ];
+
+/**
+ * Why a vendored upstream test is not built.
+ *
+ * - `dynamic-linking-build` — the test builds multiple artifacts
+ *   (`-Wl,-shared` side libraries plus a `-Wl,-pie` main) and exercises
+ *   runtime dynamic linking (`dlopen`/`dlsym`), which needs both a
+ *   multi-artifact build harness and runtime dynamic-linking support
+ *   that Runno does not have. Everything else in the vendored suite
+ *   builds with the upstream `test.sh` flags (verified empirically with
+ *   wasixcc v0.4.3 on 2026-07-30).
+ */
+export type BuildExcludeReason = "dynamic-linking-build";
+
+export type BuildExcludeEntry = {
+  reason: BuildExcludeReason;
+  /** Symbols or features the test needs, for triage greps. */
+  note: string;
+};
+
+/**
+ * Every vendored test dir that is deliberately NOT built. The
+ * consistency spec asserts `WASIX_INCLUDE_DIRS ∪ WASIX_BUILD_EXCLUDES`
+ * exactly equals the vendored directory set (and that they don't
+ * overlap). Keep alphabetised.
+ */
+export const WASIX_BUILD_EXCLUDES: Record<string, BuildExcludeEntry> = {
+  "dl-cache": {
+    reason: "dynamic-linking-build",
+    note: "dlopen/dlsym; builds libside1.so/libside2.so + pie main",
+  },
+  "dl-needed": {
+    reason: "dynamic-linking-build",
+    note: "dlopen/dlsym + DT_NEEDED chain; multi-.so build",
+  },
+  "dl-tls": {
+    reason: "dynamic-linking-build",
+    note: "TLS across shared libraries; multi-.so build",
+  },
+  dlopen: {
+    reason: "dynamic-linking-build",
+    note: "dlopen/dlsym; builds libside.so + pie main",
+  },
+};

--- a/packages/wasi/tests/wasix-suite.skip.ts
+++ b/packages/wasi/tests/wasix-suite.skip.ts
@@ -2,7 +2,15 @@
 //
 // Each entry is keyed by the test directory name (matching the `.wasm`
 // stem under `public/bin/wasix-tests/`). Tests listed here are marked
-// `test.fixme()` by the Playwright spec with a structured reason token.
+// `test.fail()` by the Playwright spec with a structured reason token —
+// they still RUN, so the report flags "passed unexpectedly" the moment a
+// capability lands and an entry goes stale.
+//
+// Scope rule (enforced by `wasix-suite-consistency.spec.ts`): every key
+// here must be a member of `WASIX_INCLUDE_DIRS` — i.e. a test that is
+// actually built and executed. Tests that cannot even be built live in
+// `WASIX_BUILD_EXCLUDES` in the constants file instead; tests that don't
+// exist in the vendored checkout must not appear anywhere.
 //
 // Reason tokens are drawn from the fixed union below. The token names are
 // a grep contract: `grep requires-provider-sockets` is meant to return
@@ -15,16 +23,17 @@
  * tokens are shared across the whole suite.
  *
  * - `requires-asyncify`            — needs Asyncify (e.g. post-fork longjmp).
- * - `requires-provider-sockets`    — needs SocketProvider.
+ * - `requires-provider-sockets`    — needs SocketsProvider.
  * - `requires-provider-threads`    — needs ThreadsProvider.
  * - `requires-provider-futex`      — needs FutexProvider.
- * - `requires-provider-signals`    — needs SignalProvider.
- * - `requires-provider-proc`       — needs ProcessProvider / proc_fork /
+ * - `requires-provider-signals`    — needs SignalsProvider.
+ * - `requires-provider-proc`       — needs ProcProvider / proc_fork /
  *                                    proc_exec / proc_spawn.
- * - `requires-future-feature`      — capability scheduled for a later
- *                                    change where no single provider
- *                                    token fits (e.g. TTY, poll/epoll,
- *                                    drive extraction).
+ * - `requires-drive-feature`       — needs a WASIDrive capability that is
+ *                                    not modelled yet (mmap/msync,
+ *                                    symlinks, hard links, mount, fd-table
+ *                                    extraction). See WASIX-PLAN.md
+ *                                    "Drive feature workstream".
  */
 export type SkipReason =
   | "requires-asyncify"
@@ -33,7 +42,7 @@ export type SkipReason =
   | "requires-provider-futex"
   | "requires-provider-signals"
   | "requires-provider-proc"
-  | "requires-future-feature";
+  | "requires-drive-feature";
 
 export type SkipEntry = {
   reason: SkipReason;
@@ -45,44 +54,26 @@ export type SkipEntry = {
  * Skip map: `<test-name>` → skip reason.
  *
  * Keep entries alphabetised; `wasix-suite.spec.ts` reads this map and
- * marks each matching test `test.fixme(true, reason)`.
- *
- * Classification notes:
- *   - `fork*` / `spawn` / `pipe` / `unix-pipe` / `fd-pipe` →
- *     `requires-provider-proc`. `fork-longjmp` additionally needs
- *     Asyncify, which is the harder blocker so it picks
- *     `requires-asyncify` instead.
- *   - `multi-threading` → `requires-provider-threads`.
- *   - `socket-*`, `sockets` → `requires-provider-sockets`.
- *   - `signals`, `fork-signals` → `requires-provider-signals`.
- *   - `epoll` / `eventfd` / `poll` / `poll-fifo` → poll surface
- *     (`requires-future-feature`).
- *   - `tty` / `ptyname` / `ioctl` → TTY work (`requires-future-feature`).
- *   - `link`, `mount`, `readlink`, `symlink`, `shm`, `procfs` → drive
- *     features not yet represented (`requires-future-feature`).
- *   - `close-preopen`, `dup` → fd-table re-binding via `fd_renumber`,
- *     stubbed ENOSYS at the WASIX layer pending the fd-table extraction
- *     (`requires-future-feature`).
+ * marks each matching test `test.fail(true, reason)`.
  */
-// Slice 3.5 closed out the FS-category carve-outs at the drive level
-// (`./` normalisation, parent-dir-exists / parent-type validation,
-// preopen retention across `close`, `.`/`..` synthesis in readdir, and
-// the harness-side mount seeding for `/tmp` and `--volume host:guest`
-// targets). The remaining entries below are non-drive gaps —
-// fd-table extraction, sockets, mmap, proc, etc.
-
 export const WASIX_SUITE_SKIPS: Record<string, SkipEntry> = {
-  "close-preopen": {
-    reason: "requires-future-feature",
-    note:
-      "fd-table re-binding after closing a preopen needs fd_renumber, " +
-      "currently stubbed ENOSYS pending the WASIDrive fd-table extraction.",
+  cloexec: {
+    reason: "requires-asyncify",
+    note: "fork + popen; post-fork child execution needs stack reification.",
   },
-  dup: {
-    reason: "requires-future-feature",
+  "closing-pre-opened-dirs": {
+    reason: "requires-drive-feature",
     note:
-      "dup2 = fd_renumber, deliberately stubbed ENOSYS — fd-table mgmt " +
-      "is co-located with WASIDrive and will lift later.",
+      "guest fcloses stdout and expects later writes to vanish; stdio " +
+      "fds route to host callbacks and never close. Surfaced by the " +
+      "stdout-diff assertion (previously passed vacuously on exit code " +
+      "alone). Pending the fd-table extraction.",
+  },
+  "context-switching": {
+    reason: "requires-asyncify",
+    note:
+      "userspace context_create/context_switch — needs the guest stack " +
+      "reified, same blocker class as Asyncify. Also uses fork/vfork.",
   },
   "fd-close": {
     reason: "requires-provider-sockets",
@@ -91,37 +82,43 @@ export const WASIX_SUITE_SKIPS: Record<string, SkipEntry> = {
       "expects close(fd) plus EBADF on second close. Needs " +
       "SocketsProvider + /bin preopen.",
   },
-  "fs-mount": {
-    reason: "requires-future-feature",
-    note: "mount syscall; Runno has a single preopen root.",
+  fork: {
+    reason: "requires-asyncify",
+    note: "post-fork execution in the child needs stack reification.",
   },
-  "mount-tmp-locally": {
-    reason: "requires-future-feature",
-    note: "mount syscall; Runno has a single preopen root.",
+  "fs-mount": {
+    reason: "requires-drive-feature",
+    note:
+      "mount syscall; Runno has a single preopen root. Only the " +
+      "--volume invocation of upstream run.sh is replicated here.",
   },
   "msync-end-of-file": {
-    reason: "requires-future-feature",
+    reason: "requires-drive-feature",
     note: "mmap / msync — WASIDrive doesn't model file-backed mappings.",
   },
   "msync-middle-of-file": {
-    reason: "requires-future-feature",
+    reason: "requires-drive-feature",
     note: "mmap / msync — WASIDrive doesn't model file-backed mappings.",
   },
   "msync-start-of-file": {
-    reason: "requires-future-feature",
+    reason: "requires-drive-feature",
     note: "mmap / msync — WASIDrive doesn't model file-backed mappings.",
   },
   "munmap-sync-end-of-file": {
-    reason: "requires-future-feature",
+    reason: "requires-drive-feature",
     note: "mmap / munmap — WASIDrive doesn't model file-backed mappings.",
   },
   "munmap-sync-middle-of-file": {
-    reason: "requires-future-feature",
+    reason: "requires-drive-feature",
     note: "mmap / munmap — WASIDrive doesn't model file-backed mappings.",
   },
   "munmap-sync-start-of-file": {
-    reason: "requires-future-feature",
+    reason: "requires-drive-feature",
     note: "mmap / munmap — WASIDrive doesn't model file-backed mappings.",
+  },
+  pipes: {
+    reason: "requires-asyncify",
+    note: "fork/vfork-based pipe plumbing.",
   },
   popen: {
     reason: "requires-provider-proc",
@@ -131,99 +128,57 @@ export const WASIX_SUITE_SKIPS: Record<string, SkipEntry> = {
     reason: "requires-provider-proc",
     note: "needs proc_spawn2 + proc_join (proc provider).",
   },
+  "proc-exec": {
+    reason: "requires-asyncify",
+    note: "fork then execv; the child resumes post-fork before exec.",
+  },
+  "proc-exec2": {
+    reason: "requires-asyncify",
+    note: "fork then execve; the child resumes post-fork before exec.",
+  },
   "read-after-munmap": {
-    reason: "requires-future-feature",
+    reason: "requires-drive-feature",
     note: "mmap / munmap — WASIDrive doesn't model file-backed mappings.",
   },
+  "share-tmp-after-fork": {
+    reason: "requires-asyncify",
+    note: "fork-based; child resumes post-fork.",
+  },
+  "share-tmp-after-proc-exec": {
+    reason: "requires-asyncify",
+    note: "fork + execv; child resumes post-fork before exec.",
+  },
+  "share-tmp-after-proc-exec2": {
+    reason: "requires-asyncify",
+    note: "fork + execve; child resumes post-fork before exec.",
+  },
+  "shared-fd": {
+    reason: "requires-asyncify",
+    note: "fork-based fd sharing; child resumes post-fork.",
+  },
+  signal: {
+    reason: "requires-asyncify",
+    note:
+      "fork-based signal delivery between processes; fork is the " +
+      "harder blocker so it wins the token over provider-signals.",
+  },
   "symlink-open-read-write": {
-    reason: "requires-future-feature",
-    note: "symlinks are not represented in WASIDrive.",
+    reason: "requires-drive-feature",
+    note:
+      "symlinks are not represented in WASIDrive. When unskipped, the " +
+      "harness must also pre-seed target.txt ('host-prefix:') and " +
+      "post-assert its content — see run.sh.",
   },
   udp: {
     reason: "requires-provider-sockets",
-    note: "raw UDP send/recv — needs SocketsProvider.",
+    note: "raw UDP send/recv across 4 subcommand invocations.",
   },
   vfork: {
     reason: "requires-provider-proc",
     note:
       "needs proc_fork_env + proc_exec3 (proc provider). Distinct from " +
-      "POSIX vfork — wasix-libc reuses proc_fork semantics.",
+      "POSIX vfork — wasix-libc reuses proc_fork semantics. Upstream " +
+      "also builds a wasm-exceptions variant (main-eh.wasm) that this " +
+      "harness does not reproduce.",
   },
-  epoll: {
-    reason: "requires-future-feature",
-    note: "epoll surface lands with the poll feature.",
-  },
-  eventfd: {
-    reason: "requires-future-feature",
-    note: "eventfd surface lands with the poll feature.",
-  },
-  "fd-pipe": {
-    reason: "requires-provider-proc",
-    note: "anonymous pipe pair — needs process/pipe plumbing.",
-  },
-  fork: { reason: "requires-provider-proc" },
-  "fork-and-exec": { reason: "requires-provider-proc" },
-  "fork-longjmp": {
-    // Needs both Asyncify (post-fork longjmp) and the process provider.
-    // Asyncify is the harder blocker so it wins the token.
-    reason: "requires-asyncify",
-    note: "post-fork longjmp requires Asyncify.",
-  },
-  "fork-pipes": { reason: "requires-provider-proc" },
-  "fork-signals": {
-    reason: "requires-provider-signals",
-    note: "signal delivery across fork — signals provider drives this.",
-  },
-  ioctl: {
-    reason: "requires-future-feature",
-    note: "TTY ioctls — lands with TTY work.",
-  },
-  link: {
-    reason: "requires-future-feature",
-    note: "hard links; WASIDrive has no link table.",
-  },
-  mount: {
-    reason: "requires-future-feature",
-    note: "mount syscall; Runno has a single preopen root.",
-  },
-  "multi-threading": { reason: "requires-provider-threads" },
-  pipe: { reason: "requires-provider-proc" },
-  poll: {
-    reason: "requires-future-feature",
-    note: "poll surface lands with the poll feature.",
-  },
-  "poll-fifo": {
-    reason: "requires-future-feature",
-    note: "poll surface lands with the poll feature.",
-  },
-  procfs: {
-    reason: "requires-future-feature",
-    note: "Wasmer-specific /proc view — deferred alongside drive extraction.",
-  },
-  ptyname: {
-    reason: "requires-future-feature",
-    note: "TTY feature — lands with TTY work.",
-  },
-  readlink: {
-    reason: "requires-future-feature",
-    note: "Symlinks are not represented in WASIDrive.",
-  },
-  shm: {
-    reason: "requires-future-feature",
-    note: "POSIX shared memory — deferred alongside drive extraction.",
-  },
-  signals: { reason: "requires-provider-signals" },
-  "socket-tcp": { reason: "requires-provider-sockets" },
-  "socket-udp": { reason: "requires-provider-sockets" },
-  sockets: { reason: "requires-provider-sockets" },
-  spawn: { reason: "requires-provider-proc" },
-  symlink: {
-    reason: "requires-future-feature",
-    note: "Symlinks are not represented in WASIDrive.",
-  },
-  tty: {
-    reason: "requires-future-feature",
-    note: "TTY semantics — lands with TTY work.",
-  },
-  "unix-pipe": { reason: "requires-provider-proc" },
 };

--- a/packages/wasi/tests/wasix-suite.spec.ts
+++ b/packages/wasi/tests/wasix-suite.spec.ts
@@ -1,19 +1,31 @@
 // Wasmer wasix integration suite runner.
 //
 // Iterates over every `.wasm` under `public/bin/wasix-tests/` that the
-// build harness produced, runs it through `WASIX.start` in each browser
-// project, and expects exit code 0.
+// build harness produced, replicates each upstream `run.sh` invocation
+// through `WASIX.start` in each browser project, and asserts the same
+// things the upstream runner asserts:
 //
-// Tests listed in `WASIX_SUITE_SKIPS` are marked `test.fixme()` with the
-// structured reason token — they still show up in the Playwright report
-// so triage can see the categorised skip distribution.
+//   1. Exit code 0 for every `$WASMER_RUN main.wasm …` invocation that
+//      upstream doesn't mark `|| true`.
+//   2. When run.sh validates stdout via the
+//      `$WASMER_RUN main.wasm … > output` + `printf "…" | diff -u output -`
+//      pattern, the captured stdout must byte-equal the printf payload.
+//      (20 of the included tests print "0" on success — exit code alone
+//      would be vacuous for them.)
+//
+// Tests listed in `WASIX_SUITE_SKIPS` are marked `test.fail()` with the
+// structured reason token — they still execute, so the Playwright report
+// flags "passed unexpectedly" the moment a capability lands and the skip
+// entry goes stale.
 //
 // Per-test wiring:
-//   - Each wasmer test directory ships a `run.sh` of the form:
-//       `$WASMER_RUN main.wasm --volume . -- <subcommand tokens>`
-//     The tokens after `--` are the guest `args`. The harness parses
-//     them at Node-time and passes them into `page.evaluate` so each
-//     test sees the right argv.
+//   - Each wasmer test directory ships a `run.sh` containing one or more
+//     `$WASMER_RUN main.wasm --volume . -- <subcommand tokens>` lines
+//     (possibly prefixed with `timeout …`). Every such line becomes one
+//     invocation; the tokens after `--` are that invocation's argv.
+//     Lines that run other artifacts (main-eh.wasm, .webc packages) or
+//     wasixcc compile steps are not replicated — see the audit notes in
+//     `wasix-suite.constants.ts`.
 //   - `--volume .` maps the test directory's input files (everything
 //     beyond `main.c` / `run.sh`) into the guest's preopen tree. The
 //     wasmer runner mounts `--volume .` at `/home` because that's
@@ -22,8 +34,9 @@
 //     provider exposes `/home` as a preopen at fd 4, and `PWD` is set
 //     so libc's startup path resolver finds the cwd before calling
 //     `getcwd`.
-//   - Each test run starts with a fresh in-memory filesystem seeded
-//     from those inputs, so per-test isolation is preserved.
+//   - Filesystem state persists ACROSS invocations within one test
+//     (mirroring the wasmer runner, where every invocation mounts the
+//     same host directory), and is fresh BETWEEN tests.
 
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
@@ -68,10 +81,34 @@ type TestInput = {
   bytes: number[];
 };
 
+type Invocation = {
+  /** Guest argv (excluding argv[0]; the runtime prepends the name). */
+  args: string[];
+  /** True when the run line redirects stdout to the `output` capture. */
+  capturesOutput: boolean;
+  /** Upstream suffixes the line with `|| true` — failure tolerated. */
+  mayFail: boolean;
+};
+
 type TestPlan = {
   name: string;
   wasmUrl: string;
-  args: string[];
+  /**
+   * Whether run.sh sets `set -e`. With it, every invocation must exit 0
+   * (any failure fails the upstream script). Without it, upstream's
+   * validation is the stdout diff alone when present — the guest's exit
+   * code is not observed (e.g. `exception` exits 42 by design) — or,
+   * with no diff either, the script's status is its last command's.
+   */
+  hasSetE: boolean;
+  /** One entry per `$WASMER_RUN main.wasm` line in run.sh, in order. */
+  invocations: Invocation[];
+  /**
+   * Expected stdout for output-capturing invocations, parsed from the
+   * `printf "…" | diff -u output -` validation line. Null when run.sh
+   * validates by exit code only.
+   */
+  expectedStdout: string | null;
   inputs: TestInput[];
   /**
    * Absolute guest paths that the wasmer runner mounts via
@@ -80,6 +117,12 @@ type TestPlan = {
    * mounts pass POSIX parent-exists checks.
    */
   mounts: string[];
+};
+
+type InvocationResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
 };
 
 function listWasmBinaries(): string[] {
@@ -93,25 +136,94 @@ function listWasmBinaries(): string[] {
 }
 
 /**
- * Extract the subcommand tokens from a wasmer `run.sh`.
- *
- * Expected shape:
- *   `$WASMER_RUN main.wasm --volume . -- <subcommand tokens>`
- * Tokens after the first `--` are returned as the guest argv (excluding
- * argv[0]; the runtime prepends the program name). If the script doesn't
- * contain a `--` separator, returns an empty array.
- *
- * Handles `\`-continued line joins, strips a leading `#!` shebang and
- * blank/comment lines, and tokenises the run line with a small POSIX-ish
- * splitter that honours single/double quotes and backslash escapes. We
- * don't need full shell semantics — every wasmer run.sh is a single
- * top-level invocation of the wasmer runner.
+ * Normalised, comment-free, continuation-joined lines of a run.sh.
  */
-function parseRunSh(source: string): string[] {
-  const tokens = runShTokens(source);
-  const sep = tokens.indexOf("--");
-  if (sep === -1) return [];
-  return tokens.slice(sep + 1);
+function runShLines(source: string): string[] {
+  return (
+    source
+      .split("\n")
+      .filter((line) => !line.startsWith("#!") && !/^\s*#/.test(line))
+      .map((line) => line.trimEnd())
+      .join("\n")
+      // Join backslash-continued lines.
+      .replace(/\\\n/g, " ")
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+  );
+}
+
+/**
+ * Parse every `$WASMER_RUN main.wasm …` line into an invocation. Lines
+ * running other artifacts (main-eh.wasm, webc packages, bare `.`) and
+ * wasixcc/wasm-opt compile steps are intentionally not replicated.
+ */
+function parseInvocations(source: string): Invocation[] {
+  const invocations: Invocation[] = [];
+  for (const line of runShLines(source)) {
+    let tokens = shellSplit(line);
+
+    // `|| true` suffix — upstream tolerates the failure.
+    let mayFail = false;
+    if (
+      tokens.length >= 2 &&
+      tokens[tokens.length - 2] === "||" &&
+      tokens[tokens.length - 1] === "true"
+    ) {
+      mayFail = true;
+      tokens = tokens.slice(0, -2);
+    }
+
+    // The runner token may be prefixed (e.g. `timeout -s 9 -v 5 $WASMER_RUN …`).
+    // `main-not-asyncified.wasm` (posix_spawn) is upstream's plain build —
+    // the same artifact our harness produces as <name>.wasm.
+    const runnerIdx = tokens.indexOf("$WASMER_RUN");
+    const artifact = tokens[runnerIdx + 1];
+    if (
+      runnerIdx === -1 ||
+      (artifact !== "main.wasm" && artifact !== "main-not-asyncified.wasm")
+    ) {
+      continue;
+    }
+    const rest = tokens.slice(runnerIdx + 2);
+
+    // Strip shell redirections, noting the `> output` capture.
+    let capturesOutput = false;
+    const cleaned: string[] = [];
+    for (let i = 0; i < rest.length; i++) {
+      const tok = rest[i];
+      const redirect = /^([12]?>>?)(.*)$/.exec(tok);
+      if (redirect) {
+        const target = redirect[2] !== "" ? redirect[2] : rest[++i];
+        if (redirect[1] === ">" && target === "output") {
+          capturesOutput = true;
+        }
+        continue;
+      }
+      cleaned.push(tok);
+    }
+
+    const sep = cleaned.indexOf("--");
+    const args = sep === -1 ? [] : cleaned.slice(sep + 1);
+    invocations.push({ args, capturesOutput, mayFail });
+  }
+  return invocations;
+}
+
+/**
+ * Extract the expected stdout from the upstream validation line
+ * `printf "<payload>" | diff -u output -`. Returns null when run.sh has
+ * no such line (exit-code-only validation). Decodes the printf escapes
+ * that appear upstream (\n, \t, \\).
+ */
+function parseExpectedStdout(source: string): string | null {
+  const match =
+    /printf\s+"((?:[^"\\]|\\.)*)"\s*\|\s*diff\s+-u\s+output\s+-/.exec(source);
+  if (!match) return null;
+  return match[1]
+    .replace(/\\n/g, "\n")
+    .replace(/\\t/g, "\t")
+    .replace(/\\\\/g, "\\");
 }
 
 /**
@@ -126,60 +238,38 @@ function parseRunSh(source: string): string[] {
  * parent-exists check (the wasmer runner provides them implicitly).
  */
 function parseRunShVolumeMounts(source: string): string[] {
-  const tokens = runShTokens(source);
-  const stop = tokens.indexOf("--");
-  const head = stop === -1 ? tokens : tokens.slice(0, stop);
   const targets: string[] = [];
-  for (let i = 0; i < head.length; i++) {
-    const tok = head[i];
-    let arg: string | undefined;
-    if (tok === "--volume" || tok === "--mapdir") {
-      arg = head[i + 1];
-      i++;
-    } else if (tok.startsWith("--volume=") || tok.startsWith("--mapdir=")) {
-      arg = tok.slice(tok.indexOf("=") + 1);
-    } else {
-      continue;
-    }
-    if (!arg) continue;
-    const colon = arg.indexOf(":");
-    if (colon === -1) continue;
-    const guest = arg.slice(colon + 1);
-    if (guest.startsWith("/")) {
-      targets.push(guest);
+  for (const line of runShLines(source)) {
+    const tokens = shellSplit(line);
+    if (tokens.indexOf("$WASMER_RUN") === -1) continue;
+    for (let i = 0; i < tokens.length; i++) {
+      const tok = tokens[i];
+      let arg: string | undefined;
+      if (tok === "--volume" || tok === "--mapdir") {
+        arg = tokens[i + 1];
+        i++;
+      } else if (tok.startsWith("--volume=") || tok.startsWith("--mapdir=")) {
+        arg = tok.slice(tok.indexOf("=") + 1);
+      } else {
+        continue;
+      }
+      if (!arg) continue;
+      const colon = arg.indexOf(":");
+      if (colon === -1) continue;
+      const guest = arg.slice(colon + 1);
+      if (guest.startsWith("/") && !targets.includes(guest)) {
+        targets.push(guest);
+      }
     }
   }
   return targets;
-}
-
-function runShTokens(source: string): string[] {
-  const body = source
-    .split("\n")
-    .filter((line) => !line.startsWith("#!") && !/^\s*#/.test(line))
-    .map((line) => line.trimEnd())
-    .join("\n")
-    // Join backslash-continued lines.
-    .replace(/\\\n/g, " ");
-
-  // Find the run line: the first line that mentions `main.wasm` (every
-  // wasmer run.sh invokes the runner on exactly one wasm artifact).
-  const runLine = body
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0)
-    .find((line) => line.includes("main.wasm"));
-
-  if (!runLine) return [];
-
-  return shellSplit(runLine);
 }
 
 /**
  * Minimal POSIX-style tokeniser: splits on whitespace, honours single
  * and double quotes, and treats `\<ch>` as a literal. Does not expand
  * variables or globs — wasmer `run.sh` scripts are trivial enough that
- * literal tokens survive intact (the `$WASMER_RUN` placeholder tokens
- * are discarded because none of them appear after `--`).
+ * literal tokens survive intact.
  */
 function shellSplit(input: string): string[] {
   const out: string[] = [];
@@ -263,25 +353,28 @@ function collectInputs(dir: string): TestInput[] {
 function planForTest(name: string): TestPlan {
   const srcDir = join(wasixTestsDir, name);
   const runShPath = join(srcDir, "run.sh");
-  let args: string[] = [];
+  let invocations: Invocation[] = [];
+  let expectedStdout: string | null = null;
   let mounts: string[] = [];
+  let hasSetE = false;
   if (existsSync(runShPath)) {
     const source = readFileSync(runShPath, "utf8");
-    try {
-      args = parseRunSh(source);
-    } catch {
-      args = [];
-    }
-    try {
-      mounts = parseRunShVolumeMounts(source);
-    } catch {
-      mounts = [];
-    }
+    invocations = parseInvocations(source);
+    expectedStdout = parseExpectedStdout(source);
+    mounts = parseRunShVolumeMounts(source);
+    hasSetE = /^set -e/m.test(source);
+  }
+  if (invocations.length === 0) {
+    // A binary with no parseable run line still gets one plain run so
+    // the suite never silently skips execution.
+    invocations = [{ args: [], capturesOutput: false, mayFail: false }];
   }
   return {
     name,
     wasmUrl: `/bin/wasix-tests/${name}.wasm`,
-    args,
+    hasSetE,
+    invocations,
+    expectedStdout,
     inputs: collectInputs(srcDir),
     mounts,
   };
@@ -321,95 +414,135 @@ test.describe("wasix integration suite (wasmer/tests/wasix)", () => {
             ? `${skip.reason} — ${skip.note}`
             : skip.reason,
         });
-        test.fixme(true, `wasix-skip:${skip.reason}`);
+        // fail (not fixme): the test still runs, so a capability landing
+        // upstream of a stale skip entry shows up as "passed unexpectedly".
+        test.fail(true, `wasix-skip:${skip.reason}`);
       }
 
-      const result = await page.evaluate(async (p: TestPlan) => {
-        while (
-          (window as unknown as { WASIX?: unknown })["WASIX"] === undefined
-        ) {
-          await new Promise((resolve) => setTimeout(resolve, 10));
-        }
+      const results: InvocationResult[] = await page.evaluate(
+        async (p: TestPlan) => {
+          while (
+            (window as unknown as { WASIX?: unknown })["WASIX"] === undefined
+          ) {
+            await new Promise((resolve) => setTimeout(resolve, 10));
+          }
 
-        const w = window as unknown as {
-          WASIX: typeof WASIX;
-          WASIXContext: typeof WASIXContext;
-          WASIDriveFileSystemProvider: typeof WASIDriveFileSystemProvider;
-        };
-        const W = w.WASIX;
-        const WC = w.WASIXContext;
-        const WD = w.WASIDriveFileSystemProvider;
-
-        // Seed a fresh WASIFS under /home for this run — the wasmer
-        // runner mounts `--volume .` at /home (wasix-libc's default
-        // cwd), so per-test inputs land at /home/<rel-path>. The
-        // provider exposes /home as a preopen at fd 4 alongside the
-        // implicit fd 3 = ".", and PWD primes the libc startup
-        // resolver before it falls back to getcwd().
-        const now = new Date();
-        const fs: WASIFS = {};
-        for (const input of p.inputs) {
-          const guestPath = `/home/${input.path}`;
-          fs[guestPath] = {
-            path: guestPath,
-            timestamps: { access: now, modification: now, change: now },
-            mode: "binary",
-            content: new Uint8Array(input.bytes),
+          const w = window as unknown as {
+            WASIX: typeof WASIX;
+            WASIXContext: typeof WASIXContext;
+            WASIDriveFileSystemProvider: typeof WASIDriveFileSystemProvider;
           };
+          const W = w.WASIX;
+          const WC = w.WASIXContext;
+          const WD = w.WASIDriveFileSystemProvider;
+
+          // Seed a fresh WASIFS under /home for this test — the wasmer
+          // runner mounts `--volume .` at /home (wasix-libc's default
+          // cwd), so per-test inputs land at /home/<rel-path>. The
+          // provider exposes /home as a preopen at fd 4 alongside the
+          // implicit fd 3 = ".", and PWD primes the libc startup
+          // resolver before it falls back to getcwd().
+          const now = new Date();
+          const fs: WASIFS = {};
+          for (const input of p.inputs) {
+            const guestPath = `/home/${input.path}`;
+            fs[guestPath] = {
+              path: guestPath,
+              timestamps: { access: now, modification: now, change: now },
+              mode: "binary",
+              content: new Uint8Array(input.bytes),
+            };
+          }
+
+          // Pre-seed each `--volume host:guest` target plus the implicit
+          // `/tmp` MemFS mount as empty directories. The WASIDrive uses
+          // `.runno` sentinel files to model directory presence, so the
+          // mount points appear as real dirs to subsequent path ops
+          // (POSIX parent-exists checks). Mirrors what the wasmer runner
+          // provides without requiring per-test harness wiring.
+          for (const guest of ["/tmp", ...p.mounts]) {
+            const trimmed = guest.endsWith("/") ? guest.slice(0, -1) : guest;
+            if (!trimmed) continue;
+            const marker = `${trimmed}/.runno`;
+            fs[marker] = {
+              path: marker,
+              timestamps: { access: now, modification: now, change: now },
+              mode: "string",
+              content: "",
+            };
+          }
+
+          const preopens = [{ name: "/home", prefix: "/home/" }];
+          // The wasmer runner mounts the same host directory for every
+          // invocation in run.sh, so file state persists across
+          // invocations within a test. Reuse the drive between runs;
+          // each invocation gets a fresh provider (fresh fd table) over
+          // the same underlying files.
+          let provider = new WD(fs, { preopens });
+
+          const results: Array<{
+            exitCode: number;
+            stdout: string;
+            stderr: string;
+          }> = [];
+
+          // Fetch once; each invocation restarts the module from a
+          // fresh instance via WASIX.start on a cloned Response.
+          const wasmResponse = await fetch(p.wasmUrl);
+          const wasmBytes = await wasmResponse.arrayBuffer();
+
+          for (const invocation of p.invocations) {
+            let stdout = "";
+            let stderr = "";
+            const wasiResult = await W.start(
+              Promise.resolve(new Response(wasmBytes.slice(0))),
+              new WC({
+                args: invocation.args,
+                env: { PWD: "/home" },
+                stdout: (out: string) => {
+                  stdout += out;
+                },
+                stderr: (err: string) => {
+                  stderr += err;
+                },
+                stdin: () => null,
+                fs: provider,
+              }),
+            );
+            results.push({ exitCode: wasiResult.exitCode, stdout, stderr });
+            provider = new WD(provider.drive, { preopens });
+          }
+
+          return results;
+        },
+        plan,
+      );
+
+      expect(results.length).toBe(plan.invocations.length);
+      for (let i = 0; i < results.length; i++) {
+        const invocation = plan.invocations[i];
+        const result = results[i];
+        const isLast = i === results.length - 1;
+        const label =
+          `invocation ${i + 1}/${results.length}` +
+          ` (args: ${JSON.stringify(invocation.args)})` +
+          `\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`;
+
+        // Mirror the upstream script's own success condition (see
+        // TestPlan.hasSetE): `set -e` scripts require every invocation
+        // to exit 0; scripts without it validate via the stdout diff
+        // when one exists, else via the last command's exit status.
+        if (plan.hasSetE) {
+          if (!invocation.mayFail) {
+            expect(result.exitCode, label).toBe(0);
+          }
+        } else if (plan.expectedStdout === null && isLast) {
+          expect(result.exitCode, label).toBe(0);
         }
-
-        // Pre-seed each `--volume host:guest` target plus the implicit
-        // `/tmp` MemFS mount as empty directories. The WASIDrive uses
-        // `.runno` sentinel files to model directory presence, so the
-        // mount points appear as real dirs to subsequent path ops
-        // (POSIX parent-exists checks). Mirrors what the wasmer runner
-        // provides without requiring per-test harness wiring.
-        for (const guest of ["/tmp", ...p.mounts]) {
-          const trimmed = guest.endsWith("/") ? guest.slice(0, -1) : guest;
-          if (!trimmed) continue;
-          const marker = `${trimmed}/.runno`;
-          fs[marker] = {
-            path: marker,
-            timestamps: { access: now, modification: now, change: now },
-            mode: "string",
-            content: "",
-          };
+        if (invocation.capturesOutput && plan.expectedStdout !== null) {
+          expect(result.stdout, label).toBe(plan.expectedStdout);
         }
-
-        let stdout = "";
-        let stderr = "";
-
-        const wasiResult = await W.start(
-          fetch(p.wasmUrl),
-          new WC({
-            args: p.args,
-            env: { PWD: "/home" },
-            stdout: (out: string) => {
-              stdout += out;
-            },
-            stderr: (err: string) => {
-              stderr += err;
-            },
-            stdin: () => null,
-            fs: new WD(fs, {
-              preopens: [{ name: "/home", prefix: "/home/" }],
-            }),
-          }),
-        );
-
-        return {
-          exitCode: wasiResult.exitCode,
-          stdout,
-          stderr,
-        };
-      }, plan);
-
-      expect(
-        result.exitCode,
-        `args: ${JSON.stringify(plan.args)}\ninputs: ${plan.inputs
-          .map((i) => i.path)
-          .join(", ")}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
-      ).toBe(0);
+      }
     });
   }
 });

--- a/packages/wasi/tests/wasix-unit.spec.ts
+++ b/packages/wasi/tests/wasix-unit.spec.ts
@@ -1,0 +1,330 @@
+// Node-side unit tests for WASIX's pure-logic helpers — the wasm
+// import-section parser, memory/table override validation, and cwd path
+// resolution. No browser, no guest binary: these run directly in the
+// Playwright worker process.
+//
+// The parser tests hand-assemble minimal wasm binaries byte-by-byte so
+// every branch (LEB128 widths, shared flag, memory64, unknown kinds,
+// leading custom sections, malformed input) is exercised without a
+// toolchain in the loop.
+
+import { test, expect } from "@playwright/test";
+
+import {
+  parseEnvImportDescriptors,
+  readVarUint32,
+  validateMemoryOverride,
+  validateTableOverride,
+} from "../lib/wasix/module-imports";
+import { resolveAbsolute, stripLeadingSlash } from "../lib/wasix/path-utils";
+
+// ─── wasm binary assembly helpers ───────────────────────────────────────────
+
+function leb(value: number): number[] {
+  const out: number[] = [];
+  let v = value >>> 0;
+  do {
+    let byte = v & 0x7f;
+    v >>>= 7;
+    if (v !== 0) byte |= 0x80;
+    out.push(byte);
+  } while (v !== 0);
+  return out;
+}
+
+function name(str: string): number[] {
+  const bytes = Array.from(new TextEncoder().encode(str));
+  return [...leb(bytes.length), ...bytes];
+}
+
+type ImportEntry = number[];
+
+function memoryImport(
+  mod: string,
+  field: string,
+  opts: { initial: number; maximum?: number; shared?: boolean },
+): ImportEntry {
+  let flags = 0;
+  if (opts.maximum !== undefined) flags |= 0x01;
+  if (opts.shared) flags |= 0x02;
+  return [
+    ...name(mod),
+    ...name(field),
+    0x02, // kind: memory
+    flags,
+    ...leb(opts.initial),
+    ...(opts.maximum !== undefined ? leb(opts.maximum) : []),
+  ];
+}
+
+function tableImport(
+  mod: string,
+  field: string,
+  opts: { element?: number; initial: number; maximum?: number },
+): ImportEntry {
+  const flags = opts.maximum !== undefined ? 0x01 : 0x00;
+  return [
+    ...name(mod),
+    ...name(field),
+    0x01, // kind: table
+    opts.element ?? 0x70, // funcref
+    flags,
+    ...leb(opts.initial),
+    ...(opts.maximum !== undefined ? leb(opts.maximum) : []),
+  ];
+}
+
+function functionImport(mod: string, field: string, typeIdx = 0): ImportEntry {
+  return [...name(mod), ...name(field), 0x00, ...leb(typeIdx)];
+}
+
+function globalImport(mod: string, field: string): ImportEntry {
+  // valtype i32 (0x7f), immutable (0x00)
+  return [...name(mod), ...name(field), 0x03, 0x7f, 0x00];
+}
+
+function section(id: number, content: number[]): number[] {
+  return [id, ...leb(content.length), ...content];
+}
+
+function moduleWithImports(
+  entries: ImportEntry[],
+  opts: { leadingCustomSection?: boolean } = {},
+): Uint8Array {
+  const header = [0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
+  const custom = opts.leadingCustomSection
+    ? section(0, [...name("meta"), 0x01, 0x02, 0x03])
+    : [];
+  const importContent = [...leb(entries.length), ...entries.flat()];
+  return new Uint8Array([...header, ...custom, ...section(2, importContent)]);
+}
+
+// ─── parseEnvImportDescriptors ──────────────────────────────────────────────
+
+test.describe("parseEnvImportDescriptors", () => {
+  test("shared env.memory with limits", () => {
+    const bytes = moduleWithImports([
+      memoryImport("env", "memory", {
+        initial: 17,
+        maximum: 256,
+        shared: true,
+      }),
+    ]);
+    expect(parseEnvImportDescriptors(bytes)).toEqual({
+      memory: { initial: 17, maximum: 256, shared: true },
+    });
+  });
+
+  test("non-shared env.memory without maximum", () => {
+    const bytes = moduleWithImports([
+      memoryImport("env", "memory", { initial: 2 }),
+    ]);
+    expect(parseEnvImportDescriptors(bytes)).toEqual({
+      memory: { initial: 2, maximum: undefined, shared: false },
+    });
+  });
+
+  test("multi-byte LEB128 limits decode correctly", () => {
+    const bytes = moduleWithImports([
+      memoryImport("env", "memory", { initial: 300, maximum: 65536 }),
+    ]);
+    expect(parseEnvImportDescriptors(bytes)).toEqual({
+      memory: { initial: 300, maximum: 65536, shared: false },
+    });
+  });
+
+  test("env.__indirect_function_table descriptor", () => {
+    const bytes = moduleWithImports([
+      tableImport("env", "__indirect_function_table", {
+        initial: 10,
+        maximum: 100,
+      }),
+    ]);
+    expect(parseEnvImportDescriptors(bytes)).toEqual({
+      table: { element: "funcref", initial: 10, maximum: 100 },
+    });
+  });
+
+  test("memory and table together, mixed with other imports", () => {
+    const bytes = moduleWithImports([
+      functionImport("wasix_32v1", "clock_time_get"),
+      memoryImport("env", "memory", { initial: 4, shared: false }),
+      globalImport("env", "__stack_pointer"),
+      tableImport("env", "__indirect_function_table", { initial: 1 }),
+      functionImport("wasi_snapshot_preview1", "fd_write", 3),
+    ]);
+    expect(parseEnvImportDescriptors(bytes)).toEqual({
+      memory: { initial: 4, maximum: undefined, shared: false },
+      table: { element: "funcref", initial: 1, maximum: undefined },
+    });
+  });
+
+  test("non-env memory imports are ignored", () => {
+    const bytes = moduleWithImports([
+      memoryImport("other", "memory", { initial: 1 }),
+    ]);
+    expect(parseEnvImportDescriptors(bytes)).toEqual({});
+  });
+
+  test("function-only imports (preview1-style binary) yield no descriptors", () => {
+    const bytes = moduleWithImports([
+      functionImport("wasi_snapshot_preview1", "proc_exit"),
+    ]);
+    expect(parseEnvImportDescriptors(bytes)).toEqual({});
+  });
+
+  test("leading custom section is skipped", () => {
+    const bytes = moduleWithImports(
+      [memoryImport("env", "memory", { initial: 3, shared: false })],
+      { leadingCustomSection: true },
+    );
+    expect(parseEnvImportDescriptors(bytes)).toEqual({
+      memory: { initial: 3, maximum: undefined, shared: false },
+    });
+  });
+
+  test("memory64 flag decodes limits as varuint64", () => {
+    // flags 0x05 = has_max | memory64
+    const entry = [
+      ...name("env"),
+      ...name("memory"),
+      0x02,
+      0x05,
+      ...leb(5),
+      ...leb(10),
+    ];
+    const bytes = moduleWithImports([entry]);
+    expect(parseEnvImportDescriptors(bytes)).toEqual({
+      memory: { initial: 5, maximum: 10, shared: false },
+    });
+  });
+
+  test("bad magic returns empty result", () => {
+    expect(parseEnvImportDescriptors(new Uint8Array([1, 2, 3, 4]))).toEqual({});
+    const wrongMagic = moduleWithImports([
+      memoryImport("env", "memory", { initial: 1 }),
+    ]);
+    wrongMagic[0] = 0xff;
+    expect(parseEnvImportDescriptors(wrongMagic)).toEqual({});
+  });
+
+  test("unknown import kind bails without misaligned garbage", () => {
+    const bogusKind = [...name("env"), ...name("weird"), 0x07, 0x00];
+    const bytes = moduleWithImports([
+      memoryImport("env", "memory", { initial: 6, shared: false }),
+      bogusKind,
+    ]);
+    // The parser keeps whatever it decoded before the unknown kind and
+    // stops — it must not throw or return misparsed descriptors.
+    expect(parseEnvImportDescriptors(bytes)).toEqual({
+      memory: { initial: 6, maximum: undefined, shared: false },
+    });
+  });
+
+  test("readVarUint32 throws on over-long encoding", () => {
+    expect(() =>
+      readVarUint32(
+        new Uint8Array([0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01]),
+        0,
+      ),
+    ).toThrow(/malformed varuint32/);
+  });
+});
+
+// ─── override validation ────────────────────────────────────────────────────
+
+test.describe("validateMemoryOverride", () => {
+  test("accepts a matching non-shared memory", () => {
+    const memory = new WebAssembly.Memory({ initial: 2 });
+    expect(() =>
+      validateMemoryOverride(memory, { initial: 2, shared: false }),
+    ).not.toThrow();
+  });
+
+  test("accepts a matching shared memory", () => {
+    const memory = new WebAssembly.Memory({
+      initial: 1,
+      maximum: 4,
+      shared: true,
+    });
+    expect(() =>
+      validateMemoryOverride(memory, { initial: 1, maximum: 4, shared: true }),
+    ).not.toThrow();
+  });
+
+  test("rejects shared-flag mismatch in both directions", () => {
+    const plain = new WebAssembly.Memory({ initial: 1 });
+    expect(() =>
+      validateMemoryOverride(plain, { initial: 1, shared: true }),
+    ).toThrow(/shared/);
+
+    const shared = new WebAssembly.Memory({
+      initial: 1,
+      maximum: 2,
+      shared: true,
+    });
+    expect(() =>
+      validateMemoryOverride(shared, { initial: 1, shared: false }),
+    ).toThrow(/shared/);
+  });
+
+  test("rejects a memory smaller than the declared initial", () => {
+    const memory = new WebAssembly.Memory({ initial: 1 });
+    expect(() =>
+      validateMemoryOverride(memory, { initial: 2, shared: false }),
+    ).toThrow(/initial=2/);
+  });
+});
+
+test.describe("validateTableOverride", () => {
+  test("accepts a table at least as large as the declared initial", () => {
+    const table = new WebAssembly.Table({ element: "anyfunc", initial: 5 });
+    expect(() =>
+      validateTableOverride(table, { element: "funcref", initial: 5 }),
+    ).not.toThrow();
+  });
+
+  test("rejects a table smaller than the declared initial", () => {
+    const table = new WebAssembly.Table({ element: "anyfunc", initial: 1 });
+    expect(() =>
+      validateTableOverride(table, { element: "funcref", initial: 3 }),
+    ).toThrow(/initial=3/);
+  });
+});
+
+// ─── path resolution ────────────────────────────────────────────────────────
+
+test.describe("resolveAbsolute", () => {
+  test("joins relative paths against the cwd", () => {
+    expect(resolveAbsolute("/home", "foo")).toBe("/home/foo");
+    expect(resolveAbsolute("/home", "foo/bar")).toBe("/home/foo/bar");
+  });
+
+  test("absolute paths bypass the cwd", () => {
+    expect(resolveAbsolute("/home", "/data/x")).toBe("/data/x");
+  });
+
+  test("folds . and .. segments", () => {
+    expect(resolveAbsolute("/home/a", "../b")).toBe("/home/b");
+    expect(resolveAbsolute("/home", "./foo/./bar")).toBe("/home/foo/bar");
+    expect(resolveAbsolute("/home/a/b", "../../c")).toBe("/home/c");
+  });
+
+  test("clamps .. at the root instead of escaping", () => {
+    expect(resolveAbsolute("/", "../../x")).toBe("/x");
+    expect(resolveAbsolute("/home", "../../../..")).toBe("/");
+  });
+
+  test("normalises trailing and duplicate slashes", () => {
+    expect(resolveAbsolute("/home", "foo/")).toBe("/home/foo");
+    expect(resolveAbsolute("/home", "foo//bar")).toBe("/home/foo/bar");
+    expect(resolveAbsolute("/", ".")).toBe("/");
+  });
+});
+
+test.describe("stripLeadingSlash", () => {
+  test("strips exactly one leading slash", () => {
+    expect(stripLeadingSlash("/home/foo")).toBe("home/foo");
+    expect(stripLeadingSlash("home/foo")).toBe("home/foo");
+  });
+});


### PR DESCRIPTION
## Why

A review of `WASIX-PLAN.md` against the landed slices found that the validation story was quietly much weaker than it looked: the suite's skip map implied coverage the harness never had, exit-code-only assertions passed vacuously for tests upstream validates by stdout diff, and the plan's own correctness bar pointed at the wrong repository. This PR makes the suite tell the truth about its coverage — and in doing so grew it substantially.

## Suite integrity

- **Exact partition of the 42 vendored upstream tests**: 38 built + run, 4 `dl-*` build-excluded (multi-`.so` dynamic linking), enforced by a new `wasix-suite-consistency.spec.ts`. A wasmer SHA bump that adds upstream tests now fails CI until they're classified. ~28 dead skip entries (for tests that don't exist in this suite at all) are deleted.
- **The "toolchain cannot link fork" premise was false.** Verified empirically with wasixcc v0.4.3: everything except `dl-*` builds when using upstream's own flags. `build-wasix-suite.ts` now mirrors upstream `test.sh` (`-sWASM_EXCEPTIONS=false`, `wasix++` for C++ tests, per-test `.flags`), growing the built suite from 25 to 38 tests.
- Six newer `wasix_32v1` imports the fork-family binaries need (`futex_wake_all`, `proc_spawn3`, `proc_exec4`, `context_*`) are stubbed ENOSYS per the plan's unwired-slot rule.

## Honest assertions

- The harness now replicates upstream validation semantics: **every** `$WASMER_RUN` line runs (multi-invocation tests like `udp` ×4, `vfork` ×9), stdout is diffed against the `printf "…" | diff -u output -` pattern, and exit codes are honoured per `set -e` (scripts without it ignore guest exit codes — `exception` exits 42 by design).
- This immediately caught `closing-pre-opened-dirs` **passing vacuously** — the guest prints an error after its success marker because stdio close isn't modelled; it's now a documented skip pending the fd-table slice.
- Three tests flipped to genuinely passing: `exception` and `setjmp-longjmp` (wasm-exceptions/exnref works in all three browsers — the plan's "setjmp/longjmp requires Asyncify" claim is amended) and `mount-tmp-locally`.
- Skips run as `test.fail` instead of `fixme`: skipped tests still execute, so a landed capability reports **"passed unexpectedly"** rather than leaving a stale skip.

## New coverage

- **preview1-under-WASIX** (`wasix-preview1-corpus.spec.ts`): the full caspervonb corpus (core/libc/libstd, 55 tests) through `WASIX.start`, covering the nine overridden preview1 imports and the export-memory auto-detect path. Three documented expected-failures where WASIX deliberately speaks POSIX `ENOENT` instead of preview1's `ENOTCAPABLE`.
- **Unit tests** (`wasix-unit.spec.ts`, Node-side): the wasm import-section parser (hand-assembled binaries covering LEB128 widths, shared/memory64 flags, unknown kinds, malformed input), memory/table override validation, cwd path resolution. Parser + validators extracted to `lib/wasix/module-imports.ts` / `path-utils.ts` (not re-exported from the public API).
- **Error model** (`wasix-error-model.spec.ts` + `wasix-errno.wat` probe): `WASIXError → its errno`, any other throw → `EIO`, and nothing crosses the WASM boundary as a JS exception.

## Tooling & docs

- `install-wasix-tools.sh` now actually installs wasixcc locally (macOS/Linux) via the GitHub release binaries — the `wasix.cc` web installer is broken.
- `WASIX-PLAN.md` updated: correct upstream suite named (`wasmer/tests/wasix`, not the Rust-based `wasix-integration-tests`), validation contract + toolchain facts recorded, a drive-feature workstream and slice roadmap added, and a new per-slice rule: **the vendored suite has zero thread/socket/TTY/futex tests**, so each future provider slice must land with its own fixtures.
- CI: comment drift fixed; the probe step now checks `wasix++` too (needed for the two C++ tests).

## Verification

`npx playwright test` locally: **579/579 across chromium, firefox, webkit** (unit + error-model + smoke/determinism + preview1 corpus under both WASI and WASIX + the 38-test wasmer suite with 25 expected-fails, each carrying a structured reason token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)